### PR TITLE
Simple docs change

### DIFF
--- a/Docs/Forms/Form.Validator.Extras.md
+++ b/Docs/Forms/Form.Validator.Extras.md
@@ -20,7 +20,7 @@ When added to a checkbox/radio button, and a list (*array*) of element id's can 
 
 ### Example
 
-	<input type="checkbox" class="validate-enforce-oncheck toEnforce:['name', 'email', 'phone']"/>
+	<input type="checkbox" class="validate-enforce-oncheck toEnforce:['name','email','phone']"/>
 	//when checked, the inputs with the ids 'name', 'email', and 'phone' will also be validated on change/submit
 
 	<input type="checkbox" class="validate-enforce-oncheck enforceChildrenOf:'someParent'"/>
@@ -33,7 +33,7 @@ When added to a checkbox/radio button, and a list (*array*) of element id's can 
 
 ### Example
 
-	<input type="checkbox" class="validate-ignore-oncheck toIgnore:['name', 'email', 'phone']"/>
+	<input type="checkbox" class="validate-ignore-oncheck toIgnore:['name','email','phone']"/>
 	//when checked, the inputs with the ids 'name', 'email', and 'phone' will NOT be validated on change/submit
 
 	<input type="checkbox" class="validate-ignore-oncheck ignoreChildrenOf:'someParent'"/>
@@ -48,7 +48,7 @@ When the input is checked or un-checked, the inputs defined will be toggled from
 
 ### Example
 
-	<input type="checkbox" class="validate-toggle-oncheck toToggle:['name', 'email', 'phone']"/>
+	<input type="checkbox" class="validate-toggle-oncheck toToggle:['name','email','phone']"/>
 	//when checked, the inputs with the ids 'name', 'email', and 'phone' will be validated on change/submit
 	//when unchecked, they will be ignored
 


### PR DESCRIPTION
Hey guys,

This issue took me awhile to resolve so I just wanted to make sure the right people knew about it.  If you follow the docs exactly for some of the Validator.Extras, your code will fail.  With my changes that is no longer the case.  Just trying to help!
Oh, also on the Validator.Extras page on mootools.net, in the list of bookmarks on the right there are two entries for "validate.reqchk.bynode".  The second one should be "validate.reqchk.byname"

Thanks,
Brad
