### PR TITLE
Develop drag offsets

### DIFF
--- a/Source/Drag/Drag.Move.js
+++ b/Source/Drag/Drag.Move.js
@@ -49,10 +49,15 @@ Drag.Move = new Class({
 		
 		if (this.container && $type(this.container) != 'element')
 			this.container = document.id(this.container.getDocument().body);
-		
+		var parent = element.getOffsetParent();
+		var parentStyles = parent.getStyles('border-top-width', 'border-left-width');
 		var styles = element.getStyles('left', 'top', 'position');
-		if (styles.left == 'auto' || styles.top == 'auto')
-			element.setPosition(element.getPosition(element.getOffsetParent()));
+		if (styles.left == 'auto' || styles.top == 'auto') {
+			var parentPosition = element.getPosition(parent);
+			parentPosition.x = parentPosition.x - (parentStyles['border-left-width'] ? parentStyles['border-left-width'].toInt() : 0);
+			parentPosition.y = parentPosition.y - (parentStyles['border-top-width'] ? parentStyles['border-top-width'].toInt() : 0);
+			element.setPosition(parentPosition);
+		}
 		
 		if (styles.position == 'static')
 			element.setStyle('position', 'absolute');
@@ -81,6 +86,7 @@ Drag.Move = new Class({
 			elementMargin = {},
 			elementBorder = {},
 			containerMargin = {},
+			offsetParentBorder = {},
 			offsetParentPadding = {};
 
 		['top', 'right', 'bottom', 'left'].each(function(pad){
@@ -89,6 +95,7 @@ Drag.Move = new Class({
 			elementMargin[pad] = this.element.getStyle('margin-' + pad).toInt();
 			containerMargin[pad] = this.container.getStyle('margin-' + pad).toInt();
 			offsetParentPadding[pad] = offsetParent.getStyle('padding-' + pad).toInt();
+			offsetParentBorder[pad] = offsetParent.getStyle('border-' + pad).toInt();
 		}, this);
 
 		var width = this.element.offsetWidth + elementMargin.left + elementMargin.right,
@@ -123,13 +130,14 @@ Drag.Move = new Class({
 		} else {
 			left -= elementMargin.left;
 			top -= elementMargin.top;
-			
 			if (this.container == offsetParent){
 				right -= containerBorder.left;
 				bottom -= containerBorder.top;
 			} else {
-				left += containerCoordinates.left + containerBorder.left;
-				top += containerCoordinates.top + containerBorder.top;
+				left += containerCoordinates.left + containerBorder.left - offsetParentBorder.left;
+				top += containerCoordinates.top + containerBorder.top - offsetParentBorder.top;
+				right -= offsetParentBorder.left;
+				bottom -= offsetParentBorder.top;
 			}
 		}
 		

--- a/Tests/Drag/Drag.Move_(drag_in_drag).html
+++ b/Tests/Drag/Drag.Move_(drag_in_drag).html
@@ -1,0 +1,46 @@
+<style>
+
+#big_drag
+{
+	border-top: 5px solid black;
+	border-left: 2px solid black;
+	border-right: 8px solid black;
+	border-bottom: 1px solid black;
+	width: 150px;
+	padding: 5px;
+	padding-top: 30px;
+	position: relative;
+}
+
+	#wrap
+	{
+		width: 150px;
+		height: 150px;
+		background-color: #bcd;
+	}
+
+		#small_drag
+		{
+			width: 30px;
+			height: 30px;
+			background-color: #567;
+		}
+		
+</style>
+
+	<p>you should be able to drag the dark blue box to be flush within the lighter blue box's edges.</p>
+	
+	<div id="big_drag">
+		<div id="wrap">
+			<div id="small_drag"></div>
+		</div>
+	</div>
+	
+<script src="/depender/build?require=More/Drag.Move"></script>
+<script>
+
+new Drag.Move('small_drag', {
+    container: 'wrap',
+    stopPropagation: true});
+
+</script>


### PR DESCRIPTION
Fixed issue where the drag offsetParent border was being included in the offset for the container, the container != offsetParent. Included test. Also fixed issue where, on startup, the draggable element would move when this situation was in effect because the offset calculation didn't subtract that offsetParent border.
