### PR TITLE
Add check for origin._origin in Class.Refactor

### DIFF
--- a/Source/Class/Class.Refactor.js
+++ b/Source/Class/Class.Refactor.js
@@ -26,7 +26,7 @@ Class.refactor = function(original, refactors){
 
 	$each(refactors, function(item, name){
 		var origin = original.prototype[name];
-		if (origin && (origin = origin._origin) && typeof item == 'function') original.implement(name, function(){
+		if (origin && (origin = origin._origin ? origin._origin: origin) && typeof item == 'function') original.implement(name, function(){
 			var old = this.previous;
 			this.previous = origin;
 			var value = item.apply(this, arguments);

--- a/Specs/Class/Class.Refactor.js
+++ b/Specs/Class/Class.Refactor.js
@@ -41,6 +41,16 @@ License:
 			return this.previous() + ' for reals.';
 		}
 	});
+        var Test3 = new Class({
+        });
+        Test3.prototype.origin = function() {
+                return "original origin";
+        };
+        Test3 = Class.refactor(Test3, {
+                origin: function(){
+                        return "refactored origin " + this.previous();
+                }
+        });
 
 	describe('Class.Refactor', {
 
@@ -62,7 +72,11 @@ License:
 
 		'should return an unaltered property': function(){
 			value_of(new Test().options.something).should_be('else');
-		}
+		},
+
+                'should return the original origin': function(){
+                        value_of(new Test3().origin()).should_be('refactored origin original origin');
+                }
 
 	});
 })();


### PR DESCRIPTION
Previously, when setting this.previous in Class.Refactor, the assumption was made that every function had been wrapped by MooTools, and then the previous property was set to the _origin property of the previous function object.  However, if you directly set a function on the prototype, it hasn't been wrapped.  A way around this is to simply use implement, but it's not clear that that's necessary.  This change checks for the _origin property, if it doesn't find it, it sets previous to point to just the previous function.
