### PR TITLE
Fix #299 - preventing sortables on button and input elements in tables

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -140,7 +140,11 @@ var Sortables = new Class({
 	},
 
 	start: function(event, element){
-		if (!this.idle || event.rightClick) return;
+		if (
+			!this.idle ||
+			event.rightClick ||
+			['button', 'input'].contains(event.target.get('tag'))
+		) return;
 
 		this.idle = false;
 		this.element = element;

--- a/Tests/Drag/Sortables_(table).html
+++ b/Tests/Drag/Sortables_(table).html
@@ -1,0 +1,42 @@
+
+You should be able to sort the TR elements of this table. Thouhg the input and button elements sould keep working.
+
+<table id="sortablesTable">
+	<tbody>
+		<tr>
+			<td>row 1</td>
+			<td><button>R1</button></td>
+			<td>row 1</td>
+			<td><input type="button"></td>
+		</tr>
+		<tr>
+			<td>row 2</td>
+			<td><button>R2</button></td>
+			<td><input type="text"></td>
+		</tr>
+		<tr>
+			<td>row 3</td>
+			<td><button>R3</button></td>
+			<td>row 3</td>
+		</tr>
+	</tbody>
+</table>
+
+<div id="result"></div>
+
+
+<script src="/depender/build?require=More/Sortables"></script>
+<script>
+
+thisSortables1 = new Sortables($('sortablesTable').getElement('tbody'), {
+    constrain: true,
+    clone: false,
+    snap: 6,
+    revert: true
+});
+
+$$('#sortablesTable button').addEvent('click', function(e){
+	$('result').adopt(new Element('p', {text: 'Clicked:' + e.target.get('text')}));
+});
+
+</script>


### PR DESCRIPTION
https://mootools.lighthouseapp.com/projects/24057-mootoolsmore/tickets/299-sortable-tables-in-ff-cannot-click-button-element
