### PR TITLE
Lighthouse #343 - Slider options.initialPosition enhancement

### DIFF
--- a/Source/Drag/Slider.js
+++ b/Source/Drag/Slider.js
@@ -71,7 +71,7 @@ var Slider = new Class({
 		
 		this.setRange(this.options.range);
 
-		this.knob.setStyle('position', 'relative').setStyle(this.property, this.options.initialStep ? this.toPosition(this.options.initialStep) : - this.options.offset);
+		this.knob.setStyle('position', 'relative').setStyle(this.property, - this.options.offset);
 		modifiers[this.axis] = this.property;
 		limit[this.axis] = [- this.options.offset, this.full - this.options.offset];
 
@@ -100,6 +100,7 @@ var Slider = new Class({
 
 		this.drag = new Drag(this.knob, dragOptions);
 		this.attach();
+		if (this.options.initialStep) this.set(this.options.initialStep)
 	},
 
 	attach: function(){

--- a/Tests/Drag/Slider.html
+++ b/Tests/Drag/Slider.html
@@ -1,5 +1,5 @@
 <h3 class="h3_test">100 steps, snap off</h3>
-<p>When you drag the black box horizontally the number below should change to reflect the position.</p>
+<p>When you drag the black box horizontally the number below should change to reflect the position. The step indicator should reflect the initialPosition option of 50.</p>
 <div id="area">
 	<div id="knob"></div>
 </div>
@@ -37,13 +37,16 @@
 <script src="/depender/build?require=More/Slider"></script>
 <script>
 var mySlide = new Slider($('area'), $('knob'), {
+	initialStep: 50,
 	onChange: function(pos){
 		$('upd').set('html', pos);
 	}
-}).set(0);
+});
+
 var mySlide2 = new Slider($('area2'), $('knob2'), {
 	steps: 10,
 	snap: true,
+	initialStep: 5,
 	onChange: function(pos){
 		$('upd2').set('html', pos);
 	}


### PR DESCRIPTION
Before, initialPosition did nothing more than set the knob's styles.  Now, it calls the step method.  Every time I've used Slider and set an initial position, I manually called the step method because I need it to do everything it's supposed to do, like change instance.step or any onChange events.
