### PR TITLE
Fx.Slide Height Reset

### DIFF
--- a/Docs/Fx/Fx.Slide.md
+++ b/Docs/Fx/Fx.Slide.md
@@ -25,6 +25,7 @@ The slide effect slides an Element in horizontally or vertically.  The contents 
 * mode    - (*string*; defaults to 'vertical') String to indicate what type of sliding. Can be set to 'vertical' or 'horizontal'.
 * wrapper - (*element*; defaults to this.element) Allows to set another Element as wrapper.
 * hideOverflow - (*boolean*; defaults to *true*) automatically sets the overflow of the wrapper to overflow, otherwise it inherits from the element being wrapped.
+* resetHeight - (*boolean*; defaults to *false*) Automatically resets the height of the wrapper when the slide unfold animation is completed, allowying to manipulate the content keeping it adjusting naturally.
 
 #### Properties
 

--- a/Source/Fx/Fx.Slide.js
+++ b/Source/Fx/Fx.Slide.js
@@ -29,13 +29,14 @@ Fx.Slide = new Class({
 	options: {
 		mode: 'vertical',
 		wrapper: false,
-		hideOverflow: true
+		hideOverflow: true,
+		resetHeight: false
 	},
 
 	initialize: function(element, options){
 		this.addEvent('complete', function(){
 			this.open = (this.wrapper['offset' + this.layout.capitalize()] != 0);
-			if (this.open) this.wrapper.setStyle('height', '');
+			if (this.open && this.options.resetHeight) this.wrapper.setStyle('height', '');
 		}, true);
 
 		this.element = this.subject = document.id(element);


### PR DESCRIPTION
The way it is now, with the height always reset is causing issues if you have an Element positioned or floated without a fixed height. I believe it would be better to have this as an option `resetHeight`, otherwise you won't even have control over it on your custom `onComplete`.
