### PR TITLE
Fx.Sort Method: sortByElements

### DIFF
--- a/Docs/Fx/Fx.Sort.md
+++ b/Docs/Fx/Fx.Sort.md
@@ -162,6 +162,7 @@ Sort by the order specified in a collection of elements; elements must be an arr
 
 ### Example
 
+	var mySort = new Fx.Sort($$('ul li'));
 	var elements = ['li3', 'li2', 'li1', 'li0'].map(function(el){
 		return document.id(el);
 	});


### PR DESCRIPTION
The provided example (available at http://mootools.net/docs/more-rc/more/Fx/Fx.Sort) doesn't work with 1.3. 
See https://mootools.lighthouseapp.com/projects/24057/tickets/420-fxsort-method-sortbyelements-seems-broken-in-13 for details.
jsFiddle with an "proof" is available at http://jsfiddle.net/fabian/Mxv4Q/. 
