### PR TITLE
Keys Pseudo Event

### DIFF
--- a/Docs/Element/Element.Event.Pseudos.Keys.md
+++ b/Docs/Element/Element.Event.Pseudos.Keys.md
@@ -1,7 +1,7 @@
 Element.Event.Pseudo :keys {#Pseudos}
 =====================================
 
-Defines the `:keys` Element Event Pseudo. It captures key combinations and fires an event when all keys are pressed.
+Defines the `:keys` Element Event Pseudo. It captures key combinations and fires an event when the keys are pressed.
 
 ### See Also
 
@@ -19,8 +19,8 @@ The event will only fire when a key combination is pressed. This only works with
 
 ### Example
 
-	myElement.addEvent('keydown:keys(shift+a+b)', function(){
-		alert('You pressed the following keys: shift, a and b');
+	myElement.addEvent('keydown:keys(shift+a)', function(){
+		alert('You pressed the following keys: shift and a');
 	});
 
 

--- a/Source/Element/Element.Event.Pseudos.Keys.js
+++ b/Source/Element/Element.Event.Pseudos.Keys.js
@@ -3,7 +3,7 @@
 
 name: Element.Event.Pseudos.Keys
 
-description: Adds functionallity fire events if certain keycombinations are pressed
+description: Adds functionality fire events if certain key combinations are pressed
 
 license: MIT-style license
 
@@ -19,40 +19,23 @@ provides: [Element.Event.Pseudos.Keys]
 
 (function(){
 
-var keysStoreKey = '$moo:keys-pressed',
-	keysKeyupStoreKey = '$moo:keys-keyup';
-
 
 Event.definePseudo('keys', function(split, fn, args){
 
 	var event = args[0],
-		keys = [],
-		pressed = this.retrieve(keysStoreKey, []);
+		keys = [];
 
 	keys.append(split.value.replace('++', function(){
-		keys.push('+'); // shift++ and shift+++a
+		keys.push('+'); // shift++
 		return '';
-	}).split('+'));
+	}).replace('ctrl', 'control').split('+'));
 
-	pressed.include(event.key);
-
-	if (keys.every(function(key){
-		return pressed.contains(key);
+	if (keys.every(function(part){
+		return event.key == part || event[part];
 	})) fn.apply(this, args);
 
-	this.store(keysStoreKey, pressed);
-
-	if (!this.retrieve(keysKeyupStoreKey)){
-		var keyup = function(event){
-			(function(){
-				pressed = this.retrieve(keysStoreKey, []).erase(event.key);
-				this.store(keysStoreKey, pressed);
-			}).delay(0, this); // Fix for IE
-		};
-		this.store(keysKeyupStoreKey, keyup).addEvent('keyup', keyup);
-	}
-
 });
+
 
 Object.append(Event.Keys, {
 	'shift': 16,

--- a/Specs/1.3/Element/Element.Event.Pseudos.Keys.js
+++ b/Specs/1.3/Element/Element.Event.Pseudos.Keys.js
@@ -1,5 +1,6 @@
 
-describe('Element.Event.Pseudos.Keys', function(){
+// Syn doesn't work really great in IE yet, needs a fix sometime
+if (!Browser.ie) describe('Element.Event.Pseudos.Keys', function(){
 
 	it('keys: should fire events for keyboard key combinations', function(){
 
@@ -12,13 +13,11 @@ describe('Element.Event.Pseudos.Keys', function(){
 		// shift+a
 		simulateEvent('type', ['[shift]a[shift-up]', document.body], function(){
 			expect(callback).toHaveBeenCalled();
-			document.body.eliminate('$moo:keys-pressed');
 		});
 
 		// shift++
 		simulateEvent('type', ['[shift]+[shift-up]', document.body], function(){
 			expect(callback2).toHaveBeenCalled();
-			document.body.eliminate('$moo:keys-pressed');
 		});
 
 	});

--- a/Tests/Element/Element.Event.Pseudos.Keys.html
+++ b/Tests/Element/Element.Event.Pseudos.Keys.html
@@ -2,15 +2,27 @@
 	Press shift+a and there should appear some text below
 </p>
 
-<div id="result"><h3>Keydown - press shift+a or shift+++a and the event should fire on keydown</h3></div>
-<div id="result2"><h3>Keyup - press shift+b and the event should fire on keyup</h3></div>
+<div id="result">
+	<h3>Keydown - press shift+a and the event should fire on keydown</h3>
+</div>
+
+<div id="result2">
+	<h3>Keyup - press shift+b and the event should fire on keyup</h3>
+</div>
+
+<div id="result3">
+	<h3>keydown - press shift+ctrl+x and the event should fire on keydown</h3>
+</div>
+
+<div id="result3">
+	<h3>keydown - shift and + and the event should fire on keydown</h3>
+</div>
 
 <script src="/depender/build?require=More/Element.Event.Pseudos.Keys"></script>
 
 <script>
 
 var result = $('result');
-
 document.addEvent('keydown:keys(shift+a)', function(){
 	result.set('html', result.get('html') + 'succes keydown:keys(shift+a)!<br>');
 });
@@ -20,8 +32,16 @@ document.addEvent('keyup:keys(shift+b)', function(){
 	result2.set('html', result2.get('html') + 'succes keyup:keys(shift+b)!<br>');
 });
 
-document.addEvent('keydown:keys(shift+++a)', function(e){
-	result.set('html', result.get('html') + 'succes keydown:keys(shift+++a)!<br>');
+var result3 = $('result3');
+document.addEvent('keydown:keys(shift+ctrl+x)', function(){
+	result3.set('html', result3.get('html') + 'succes keydown:keys(shift+ctrl+x)!<br>');
 });
+
+
+var result4 = $('result4');
+document.addEvent('keydown:keys(shift++)', function(e){
+	result4.set('html', result4.get('html') + 'succes keydown:keys(shift++)!<br>');
+});
+
 
 </script>


### PR DESCRIPTION
I simplified the `:keys` pseudo event a lot.

I did this for stability reasons. The previous version pushed all the pressed keys in an array till the keyup event removed them from that array. This was nice because you could do something like `:keys(a+b+c)` but I encountered some issues when i wanted to use it on jsFiddle and on Opera. The IE fix (the delay of 0ms) fixed IE, but it wasn't very pretty.

That's why I would choose for a stable solution for the 1.3.0.1 release before we break Keyboard (which relies on :keys) or get loads of tickets about :keys not working. The code is tagged as 1.3RC1 so might release that code when it's more stable.
