### PR TITLE
Support for multiple event pseudos

### DIFF
--- a/Source/Class/Events.Pseudos.js
+++ b/Source/Class/Events.Pseudos.js
@@ -55,9 +55,9 @@ Events.Pseudos = function(pseudos, addEvent, removeEvent){
                 }) : null;
 	};
 
-        var stackPseudos = function(pseudo, fn, args, proxy){
+        var stackPseudos = function(pseudo, fn, args){
             return function(){
-                pseudos[pseudo.pseudo][0].call(this, pseudo, fn, args, proxy)
+                pseudos[pseudo.pseudo][0].call(this, pseudo, fn, args, pseudos[pseudo.pseudo][1])
             }
         }
 
@@ -76,8 +76,8 @@ Events.Pseudos = function(pseudos, addEvent, removeEvent){
                             var stack = fn,
                                 last = split.getLast(),
                                 i = split.length;
-                            while (i--) stack = stackPseudos(split[i], stack, arguments, pseudos[split[i].pseudo][1]);
-                            stack.call(self, last, stack, arguments, pseudos[last.pseudo][1]);
+                            while (i--) stack = stackPseudos(split[i], stack, arguments);
+                            stack.call(self, last, stack, arguments);
 			};
 
 			events.include({event: fn, monitor: monitor});


### PR DESCRIPTION
I added support for multiple pseudos on an event, for example: $('foo').addEvent('click:relay(.bar):delay(1000)', function(){ ... }); 

One thing to review for sure is the proxy variable that is used in addEvents, I am thinking I should have assigned each proxy as it pertained to a given pseudo during the wrapping in the stackPseudos function.

Let me know what you think. This does make for some pretty sweet abilities with very little code change, and as far as I can tell, it is backwards compatible :)
