### PR TITLE
two trivial things: Master 452 docs request.queue + keyboard whitespace

### DIFF
--- a/Docs/Request/Request.Queue.md
+++ b/Docs/Request/Request.Queue.md
@@ -173,7 +173,7 @@ Returns any instances of [Request][] that are currently running (but not necessa
 
 ### Returns
 
-* *array* - An array of [Request][] instances that have open requests.
+* *object* - An object of [Request][] instances that have open requests.
 
 Request.Queue Method: send {#Request-Queue:send}
 ------------------------------------------------------

--- a/Source/Interface/Keyboard.js
+++ b/Source/Interface/Keyboard.js
@@ -51,6 +51,7 @@ provides: [Keyboard]
 			this.setOptions(options);
 			this.setup();
 		},
+
 		setup: function(){
 			this.addEvents(this.options.events);
 			//if this is the root manager, nothing manages it


### PR DESCRIPTION
lighthouse #542, Documentation: Request.Queue.getRunning()
https://mootools.lighthouseapp.com/projects/24057/tickets/452-documentation-requestqueuegetrunning#ticket-452-2
- simple docs change
- adds newline in keyboard between methods
