### PR TITLE
Master 433 firefox disable click events in sortable items

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -143,7 +143,7 @@ var Sortables = new Class({
 		if (
 			!this.idle ||
 			event.rightClick ||
-			['button', 'input'].contains(event.target.get('tag'))
+			['button', 'input', 'a'].contains(event.target.get('tag'))
 		) return;
 
 		this.idle = false;

--- a/Tests/Drag/Sortables_(table).html
+++ b/Tests/Drag/Sortables_(table).html
@@ -4,18 +4,18 @@ You should be able to sort the TR elements of this table, though the input and b
 <table id="sortablesTable">
 	<tbody>
 		<tr>
-			<td>row 1</td>
+			<td><a href="#">row 1</a></td>
 			<td><button>R1</button></td>
 			<td>row 1</td>
 			<td><input type="button"></td>
 		</tr>
 		<tr>
-			<td>row 2</td>
+			<td><a href="#">row 2</a></td>
 			<td><button>R2</button></td>
 			<td><input type="text"></td>
 		</tr>
 		<tr>
-			<td>row 3</td>
+			<td><a href="#">row 3</a></td>
 			<td><button>R3</button></td>
 			<td>row 3</td>
 		</tr>
@@ -29,13 +29,17 @@ You should be able to sort the TR elements of this table, though the input and b
 <script>
 
 thisSortables1 = new Sortables($('sortablesTable').getElement('tbody'), {
-    constrain: true,
-    clone: false,
-    snap: 6,
-    revert: true
+	constrain: true,
+	clone: false,
+	snap: 6,
+	revert: true
 });
 
 $$('#sortablesTable button').addEvent('click', function(e){
+	$('result').adopt(new Element('p', {text: 'Clicked:' + e.target.get('text')}));
+});
+
+$$('#sortablesTable a').addEvent('click', function(e){
 	$('result').adopt(new Element('p', {text: 'Clicked:' + e.target.get('text')}));
 });
 


### PR DESCRIPTION
Fix for this: 
https://mootools.lighthouseapp.com/projects/24057/tickets/433-firefox-disable-click-events-in-sortable-items

also cleans up some whitespace in sortables test
