### PR TITLE
Lighthouse #499 accordian no fx isn't returning to auto initially

### DIFF
--- a/Source/Fx/Fx.Accordion.js
+++ b/Source/Fx/Fx.Accordion.js
@@ -156,9 +156,7 @@ Fx.Accordion = new Class({
 		if (this.options.returnHeightToAuto){
 			var prev = this.elements[this.previous];
 			if (prev && !this.selfHidden){
-				for (var fx in this.effects){
-					prev.setStyle(fx, prev[this.effects[fx]]);
-				}
+				for (var fx in this.effects) prev.setStyle(fx, prev[this.effects[fx]]);
 			}
 		}
 
@@ -176,6 +174,7 @@ Fx.Accordion = new Class({
 			}
 			this.fireEvent(hide ? 'background' : 'active', [this.togglers[i], el]);
 			for (var fx in this.effects) obj[i][fx] = hide ? 0 : el[this.effects[fx]];
+			if (!useFx && !hide) obj[i]['height'] = 'auto';
 		}, this);
 
 		this.internalChain.clearChain();


### PR DESCRIPTION
https://mootools.lighthouseapp.com/projects/24057/tickets/449-fxaccordion-option-returnheighttoauto-isnt-picked-up-on-init
- small patch (with small whitespace thing)
- fixes failing test
