### PR TITLE
Master clipping fx.slide height

### DIFF
--- a/Source/Fx/Fx.Slide.js
+++ b/Source/Fx/Fx.Slide.js
@@ -51,7 +51,10 @@ Fx.Slide = new Class({
 			styles: styles
 		}).wraps(this.element);
 
-		this.element.store('wrapper', this.wrapper).setStyle('margin', 0);
+		this.element.store('wrapper', this.wrapper).setStyles({
+			'margin': 0,
+			'overflow': styles.oveflow == 'visble' ? 'auto' : styles.overflow
+		});
 		this.now = [];
 		this.open = true;
 	},

--- a/Tests/Fx/Fx.Slide.html
+++ b/Tests/Fx/Fx.Slide.html
@@ -1,5 +1,32 @@
-<div id="sliderExampleWrapper" style="width: 300px; height: 200px; border: 1px solid black;margin-left: 10px">
-	<div id="sliderButton" style="width: 100px; height: 100px; background-color: #baeeb5; border: 1px solid black"></div>
+<style>
+	#sliderExampleWrapper {
+		width: 300px;
+		height: 200px;
+		border:1px solid #000;
+		margin-left: 10px;
+	}
+	#sliderButton {
+		width: 100px;
+  }
+  #inner-box2{
+		background-color: #baeeb5;
+		height: 100px;
+  }
+	#inner-box {
+		margin-top:20px;
+		height:10px;
+		background-color: red;
+		border: 1px solid #000;
+	}
+</style>
+<p>
+	In toggling, it should return the elements to the correct height.
+</p>
+<div id="sliderExampleWrapper">
+	<div id="sliderButton">
+    <div id="inner-box"></div>
+    <div id="inner-box2"></div>
+	</div>
 </div>
 <script src="/depender/build?require=More/Fx.Slide,Core/Element.Event"></script>
 


### PR DESCRIPTION
lighthouse 194, Fx.Slide sometimes clips the contents of divs
https://mootools.lighthouseapp.com/projects/24057-mootoolsmore/tickets/194-fxslide-sometimes-clips-the-contents-of-divs#ticket-194-16
- this.element with overflow visible & first child margin exposes browser bug with
  offsetHeight... this sets elements height to overflow auto so that
  offsetHeight can be correctly calculated
