### PR TITLE
Master HtmlTable stopped accepting numbers,dates,etc...

### DIFF
--- a/Source/Interface/HtmlTable.js
+++ b/Source/Interface/HtmlTable.js
@@ -111,7 +111,7 @@ var HtmlTable = new Class({
 			var td = new Element(tag || 'td', data ? data.properties : {}),
 				type = (data ? data.content : '') || data,
 				element = document.id(type);
-			if (typeOf(type) != 'string') td.adopt(element || type);
+			if ((typeOf(type) != 'string' && element) || ['array', 'collection', 'elements'].contains(typeOf(type))) td.adopt(element || type);
 			else td.set('html', type);
 
 			return td;


### PR DESCRIPTION
HtmlTable stoped accepting non string/element collections with this commit:
https://github.com/mootools/mootools-more/commit/5709d74621cad3a0a9ab3227eca74b81bfada49c
- this fixes that
