### PR TITLE
Master 34 class.binds requires initialize

### DIFF
--- a/Source/Class/Class.Binds.js
+++ b/Source/Class/Class.Binds.js
@@ -22,6 +22,7 @@ provides: [Class.Binds]
 */
 
 Class.Mutators.Binds = function(binds){
+	if (!this.prototype.initialize) this.implement('initialize', function(){});
 	return binds;
 };
 


### PR DESCRIPTION
lighthouse 34, Class.Binds requires initialize
https://mootools.lighthouseapp.com/projects/24057/tickets/34-classbinds-requires-initialize
- adds "initialize" if it isn't already there
  - problem with scotts proposal was order dependency
- cleans up spec
- adds coverage for scotts two concerns:
  - initialize dependency
  - order dependency
