### PR TITLE
Develop keyboard drop

### DIFF
--- a/Source/Interface/Keyboard.js
+++ b/Source/Interface/Keyboard.js
@@ -126,7 +126,7 @@ provides: [Keyboard]
 
 		//management logic
 		manage: function(instance){
-			if (instance.manager && instance.manager != Keyboard.manager && this != Keyboard.manager) instance.manager.drop(instance);
+			if (instance.manager) instance.manager.drop(instance);
 			this.instances.push(instance);
 			instance.manager = this;
 			if (!this.activeKB) this.activate(instance);
@@ -137,10 +137,12 @@ provides: [Keyboard]
 		},
 
 		drop: function(instance){
-			this._disable(instance);
+			instance.relinquish();
 			this.instances.erase(instance);
-			Keyboard.manager.manage(instance);
-			if (this.activeKB == instance && this.previous && this.instances.contains(this.previous)) this.activate(this.previous);
+			if (this.activeKB == instance){
+				if (this.previous && this.instances.contains(this.previous)) this.activate(this.previous);
+				else this.activeKB = this.instances[0];
+			}
 		},
 
 		instances: [],
@@ -209,7 +211,7 @@ provides: [Keyboard]
 		var hasConsole = window.console && console.log;
 		if (hasConsole) console.log('the following items have focus: ');
 		Keyboard.each(keyboard, function(current){
-			if (hasConsole) console.log(document.id(current.widget) || current.wiget || current);
+			if (hasConsole) console.log(document.id(current.widget) || current.widget || current);
 		});
 	};
 

--- a/Specs/1.3/Interface/Keyboard.js
+++ b/Specs/1.3/Interface/Keyboard.js
@@ -64,22 +64,26 @@ if (window.addEventListener) describe('Keyboard', function(){
 
 	});
 
-	xit('should bubble up the keyboard instances', function(){
+	it('should bubble up the keyboard instances', function(){
 
 		var callback = jasmine.createSpy(), called = false;
 
 		var kb = new Keyboard({
-			events: {']': callback}
+			events: {']': callback},
+			active: true
 		});
 
 		var kb2 = new Keyboard({
-			parent: kb
+			manager: kb,
+			active: true
 		});
 
 		var kb3 = new Keyboard({
-			parent: kb2,
+			manager: kb2,
 			active: true
 		});
+
+		expect(Keyboard.manager.instances.indexOf(kb3)).toBe(-1);
 
 		Syn.key(']', document.body, function(){
 			called = true;
@@ -117,6 +121,14 @@ if (window.addEventListener) describe('Keyboard', function(){
 		runs(function(){
 			expect(callback).toHaveBeenCalled();
 		});
+
+	});
+
+	it('drop a keyboard entirely', function(){
+
+		var kb = new Keyboard();
+		Keyboard.manager.drop(kb);
+		expect(Keyboard.manager.instances.indexOf(kb)).toBe(-1);
 
 	});
 


### PR DESCRIPTION
Previously because drop called Keyboard.manager.manage(instance) it meant that the Keyboard.manager could never drop a keyboard. In theory this is fine, but in effect it meant that despite the fact that keyboards would have other managers assigned, they'd still be in the "instances" array of the Keyboard.manager forever. Now an instance can be dropped, effectively disabling it.
