### PR TITLE
Master 441 form.request.append does not animate in

### DIFF
--- a/Source/Fx/Fx.Reveal.js
+++ b/Source/Fx/Fx.Reveal.js
@@ -183,7 +183,7 @@ Fx.Reveal = new Class({
 
 	cancel: function(){
 		this.parent.apply(this, arguments);
-		this.element.style.cssText = this.cssText;
+		if (this.cssText != null) this.element.style.cssText = this.cssText;
 		this.hiding = false;
 		this.showing = false;
 		return this;

--- a/Specs/1.3/Fx/Fx.Reveal.js
+++ b/Specs/1.3/Fx/Fx.Reveal.js
@@ -1,0 +1,17 @@
+describe('Fx.Reveal', function(){
+
+	describe('set', function(){
+
+		it('it should not remove css styling', function(){
+			var el = new Element('div', { 
+				styles: {
+					display: 'none'
+				}
+			});
+			el.set('reveal', {});
+			expect(el.getStyle('display')).toEqual('none');
+		});
+
+	});
+
+});

--- a/Specs/Configuration.js
+++ b/Specs/Configuration.js
@@ -56,6 +56,7 @@ Configuration.sets = {
 			'Element/Element.Event.Pseudos', 'Element/Element.Event.Pseudos.Keys', 'Element/Element.Delegation',
 			'Types/URI', 'Types/URI.Relative',
 			'Interface/Keyboard', 'Interface/HtmlTable.Sort',
+			'Fx/Fx.Reveal',
 			'Request/Request.JSONP',
 			'Utilities/Hash.Cookie', 'Utilities/Assets'
 		]
@@ -175,6 +176,8 @@ Configuration.source = {
 			'Interface/Keyboard',
 			'Interface/HtmlTable',
 			'Interface/HtmlTable.Sort',
+
+			'Fx/Fx.Reveal',
 
 			'Request/Request.JSONP',
 

--- a/Tests/Forms/Form.Request.Append.html
+++ b/Tests/Forms/Form.Request.Append.html
@@ -10,7 +10,7 @@
 </style>
 
 <div id="update" style="width: 200px; border: 1px solid #444;padding: 10px; margin: 10px 0px;">
-	<p>this box should get new text <i>appended</i> when you click the input below.</p>
+	<p>this box should get new text <i>appended</i> when you click the input below. The text should transition in with reveal.</p>
 </div>
 
 <form id="test" action="/ajax_html_echo/" method="post">


### PR DESCRIPTION
Lighthouse 441, Form.Request.Append does not animate on call to .reveal()
https://mootools.lighthouseapp.com/projects/24057/tickets/441-formrequestappend-does-not-animate-on-call-to-reveal
- Arians commit
  (https://github.com/mootools/mootools-more/commit/64efefc04fe8fca1e9f7a5a750319a9f880ffdd7)
  changed append to use set.
  - set calls cancel
  - Aaron changed cancel to reset the css (which is good), but if this.cssText is not
    defined the css is set to nothing... (so setting an element to display
    'none' -- like in Form.Request.Append, will become 'display' 'block')
    then it won't do cool transitions in... boo
  - adds a check to make sure this doesn't happen
  - adds a note about what to look for in interactive test
  - adds spec -- hooray!
