### PR TITLE
HtmlTable Class Fix

### DIFF
--- a/Source/Interface/HtmlTable.js
+++ b/Source/Interface/HtmlTable.js
@@ -68,7 +68,10 @@ var HtmlTable = new Class({
 		}, this);
 
 		['adopt', 'inject', 'wraps', 'grab', 'replaces', 'dispose'].each(function(method){
-			this[method] = this.element[method].bind(this.element);
+			this[method] = (function(){
+				this.element[method].apply(this.element, arguments);
+				return this;
+			}).bind(this);
 		}, this);
 	},
 


### PR DESCRIPTION
I found a small bug with HtmlTable.

When calling 'class' methods that reference the table element, such as:

var myTable = new HtmlTable();
myTable.inject(someEl);

This works as intended, but if you do:

var myTable = new HtmlTable().inject(someEl);

myTable will no longer reference the HtmlTable class, but rather the table element itself.

I have updated HtmlTable.js to actually perform the element method, and then return the class instance.
