### PR TITLE
Master 468 date validator

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -422,21 +422,19 @@ Form.Validator.addAllThese([
 		},
 		test: function(element, props){
 			if (Form.Validator.getValidator('IsEmpty').test(element)) return true;
-			var date;
-			if (Date.parse){
-				var format = props.dateFormat || '%x';
-				date = Date.parse(element.get('value'));
-				var formatted = date.format(format);
+			var dateLocale = Locale.getCurrent().sets.Date,
+				dateNouns = new RegExp([dateLocale.days, dateLocale.days_abbr, dateLocale.months, dateLocale.months_abbr].flatten().join('|'), 'i'),
+				value = element.get('value'),
+				wordsInValue = value.match(/[a-z]+/gi);
+
+				if (wordsInValue && !wordsInValue.every(dateNouns.exec, dateNouns)) return false;
+
+				var date = Date.parse(value),
+					format = props.dateFormat || '%x',
+					formatted = date.format(format);
+
 				if (formatted != 'invalid date') element.set('value', formatted);
 				return date.isValid();
-			} else {
-				var regex = /^(\d{2})\/(\d{2})\/(\d{4})$/;
-				if (!regex.test(element.get('value'))) return false;
-				date = new Date(element.get('value').replace(regex, '$1/$2/$3'));
-				return (parseInt(RegExp.$1, 10) == (1 + date.getMonth())) &&
-					(parseInt(RegExp.$2, 10) == date.getDate()) &&
-					(parseInt(RegExp.$3, 10) == date.getFullYear());
-			}
 		}
 	}],
 

--- a/Specs/1.3/Forms/Form.Validator.js
+++ b/Specs/1.3/Forms/Form.Validator.js
@@ -162,9 +162,14 @@ describe('Form.Validator', function(){
 
 			var validator = getValidator('validate-date');
 
+			beforeEach(function(){
+				Locale.use('en-US');
+			});
+
 			it('should return false for fields whose value is not a date', function(){
 				expect(validator.test(createInput('Mr. Foo'))).toEqual(false);
 				expect(validator.test(createInput('blah 12, 1000'))).toEqual(false);
+				expect(validator.test(createInput('Boo 12'))).toEqual(false);
 			});
 
 			it('should return true for fields whose value parses to a date', function(){


### PR DESCRIPTION
lighthouse 468, Form.Validator should not use Date.parse for validating
https://mootools.lighthouseapp.com/projects/24057/tickets/468-formvalidator-should-not-use-dateparse-for-validating

add check for correct date nouns in date validator for failing spec "boo
12" in chrome
