### PR TITLE
Master 456 htmltable.select ie8

### DIFF
--- a/Source/Element/Element.Shortcuts.js
+++ b/Source/Element/Element.Shortcuts.js
@@ -62,11 +62,14 @@ Element.implement({
 Document.implement({
 
 	clearSelection: function(){
-		if (document.selection && document.selection.empty){
-			document.selection.empty();
-		} else if (window.getSelection){
+		if (window.getSelection){
 			var selection = window.getSelection();
 			if (selection && selection.removeAllRanges) selection.removeAllRanges();
+		} else if (document.selection && document.selection.empty){
+			try {
+				//IE fails here if selected element is not in dom
+				document.selection.empty();
+			} catch(e){}
 		}
 	}
 


### PR DESCRIPTION
lighthouse 456, html table selectRow ie8 problem
https://mootools.lighthouseapp.com/projects/24057/tickets/456-html-table-selectrow-ie8-problem
- ie8 throws runtime error with document.selection.empty() when
  selected element is not in dom
- this is a pretty common problem -- more information can be found here: http://www.telerik.com/community/forums/aspnet-ajax/window/problem-with-document-selection-empty-when-moving-radwindow.aspx
