### PR TITLE
Master 469 request.jsonp should not require request

### DIFF
--- a/Source/Request/Request.JSONP.js
+++ b/Source/Request/Request.JSONP.js
@@ -16,13 +16,14 @@ authors:
 
 requires:
   - Core/Element
-  - Core/Request
   - MooTools.More
 
 provides: [Request.JSONP]
 
 ...
 */
+
+if (!this.Request) this.Request = {};
 
 Request.JSONP = new Class({
 


### PR DESCRIPTION
Lighthouse 469, Request.JSONP should not require Request
https://mootools.lighthouseapp.com/projects/24057/tickets/469-requestjsonp-should-not-require-request
- decouples Request.JSONP from request class
