### PR TITLE
Master 443 htmltable.select empty

### DIFF
--- a/Source/Interface/HtmlTable.Select.js
+++ b/Source/Interface/HtmlTable.Select.js
@@ -54,6 +54,11 @@ HtmlTable = Class.refactor(HtmlTable, {
 		if (this.options.selectable) this.enableSelect();
 	},
 
+	empty: function(){
+		this.selectNone();
+		return this.previous();
+	},
+
 	enableSelect: function(){
 		this._selectEnabled = true;
 		this._attachSelects();

--- a/Specs/1.3/Interface/HtmlTable.Select.js
+++ b/Specs/1.3/Interface/HtmlTable.Select.js
@@ -1,0 +1,16 @@
+describe('HtmlTable.Select', function(){
+
+	it('should clear selections when emptying a table', function(){
+		var SelectableTable = new HtmlTable({
+			selectable: true,
+			useKeyboard: false,
+			rows: [[0],[1],[2]]
+		});
+
+		var row = SelectableTable.body.getChildren()[0];
+		SelectableTable.selectRow(row);
+		SelectableTable.empty();
+		expect(SelectableTable.isSelected(row)).toEqual(false);
+	});
+
+});

--- a/Specs/Configuration.js
+++ b/Specs/Configuration.js
@@ -55,9 +55,9 @@ Configuration.sets = {
 			'Element/Element.Forms', 'Element/Element.Measure', 'Element/Elements.From', 'Element/Element.Shortcuts',
 			'Element/Element.Event.Pseudos', 'Element/Element.Event.Pseudos.Keys', 'Element/Element.Delegation',
 			'Types/URI', 'Types/URI.Relative',
-			'Interface/Keyboard', 'Interface/HtmlTable', 'Interface/HtmlTable.Sort',
+			'Interface/Keyboard', 'Interface/HtmlTable', 'Interface/HtmlTable.Sort', 'Interface/Htmltable.Select',
 			'Forms/Form.Validator',
-      'Fx/Fx.Reveal',
+			'Fx/Fx.Reveal',
 			'Request/Request.JSONP',
 			'Utilities/Hash.Cookie', 'Utilities/Assets'
 		]
@@ -179,6 +179,7 @@ Configuration.source = {
 			'Interface/Keyboard',
 			'Interface/HtmlTable',
 			'Interface/HtmlTable.Sort',
+			'Interface/HtmlTable.Select',
 
 			'Fx/Fx.Reveal',
 


### PR DESCRIPTION
lighthouse #443, HtmlTable/HtmlTable.select - bug / unintuitive behavior
https://mootools.lighthouseapp.com/projects/24057/tickets/443-htmltablehtmltableselect-bug-unintuitive-behavior
- clears selections before emptying table
- adds spec!
