### PR TITLE
Master 475 sortables not cleaning clone

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -173,7 +173,7 @@ var Sortables = new Class({
 				this.fireEvent('start', [this.element, this.clone]);
 			}.bind(this),
 			onEnter: this.insert.bind(this),
-			onCancel: this.reset.bind(this),
+			onCancel: this.end.bind(this),
 			onComplete: this.end.bind(this)
 		});
 


### PR DESCRIPTION
lighthouse 475, sortables table adds lots of <tr>s
https://mootools.lighthouseapp.com/projects/24057/tickets/475-sortables-table-adds-lots-of-trs#ticket-475-2

cancel is fired from drag on mouseup -- not complete... so if you
click or mousedown on a sortable without dragging -- it was only resetting
sortables... resetting doesn't remove the clone. So we should end on
cancel instead (ending also resets)...
