### PR TITLE
Master 490 knob position

### DIFF
--- a/Source/Drag/Slider.js
+++ b/Source/Drag/Slider.js
@@ -71,7 +71,8 @@ var Slider = new Class({
 		this.setSliderDimensions();
 		this.setRange(options.range);
 
-		knob.setStyle('position', 'relative').setStyle(this.property, -options.offset);
+		if (knob.getStyle('position') == 'static') knob.setStyle('position', 'relative');
+		knob.setStyle(this.property, -options.offset);
 		modifiers[this.axis] = this.property;
 		limit[this.axis] = [-options.offset, this.full - options.offset];
 

--- a/Tests/Drag/Slider.html
+++ b/Tests/Drag/Slider.html
@@ -52,22 +52,33 @@
 	<div id="knob7"></div>
 </div>
 
+<h3 class="h3_test">This slider should work with your mousewheel</h3>
+<p>The knob's position should not be set to position relative if it is currently absolute.</p>
+<div id="area8">
+	<div id="knob8"></div>
+</div>
+
 
 <style type="text/css" media="screen">
-	#area, #area2, #area3, #area4, #area5, #area6, #area7 {
+	#area, #area2, #area3, #area4, #area5, #area6, #area7, #area8 {
 		background: #ccc;
 		height: 20px;
 		width: 200px;
+		position: relative;
 	}
 	#area6 {
 		width: 100%;
 	}
-	#knob, #knob2, #knob3, #knob4, #knob5, #knob6, #knob7 {
+	#knob, #knob2, #knob3, #knob4, #knob5, #knob6, #knob7, #knob8 {
 		height: 20px;
 		width: 20px;
 		background: #000;
 		cursor:col-resize !important;
 		cursor:pointer;
+	}
+
+	#knob8 {
+		position: absolute;
 	}
 </style>
 <script src="/depender/build?require=More/Slider"></script>
@@ -135,8 +146,9 @@ window.addEvent('resize', function(){
 	mySlideStretch.autosize();
 });
 
-var mySlide7 = new Slider('area7', 'knob7', {
+new Slider('area7', 'knob7', {
 	wheel: true
 });
 
+new Slider('area8', 'knob8');
 </script>


### PR DESCRIPTION
lighthouse #490, Slider shouldn't enforce knob to be positioned relative
https://mootools.lighthouseapp.com/projects/24057/tickets/490-slider-shouldnt-enforce-knob-to-be-positioned-relative
- only sets knob positioning to relative is knobs current positioning is
  static (because static won't respond to "left" styles)
