### PR TITLE
Remove Script type attribute in JSONP and Assets

### DIFF
--- a/Source/Request/Request.JSONP.js
+++ b/Source/Request/Request.JSONP.js
@@ -96,7 +96,7 @@ Request.JSONP = new Class({
 	},
 
 	getScript: function(src){
-		if (!this.script) this.script = new Element('script[type=text/javascript]', {
+		if (!this.script) this.script = new Element('script', {
 			async: true,
 			src: src
 		});

--- a/Source/Utilities/Assets.js
+++ b/Source/Utilities/Assets.js
@@ -26,7 +26,7 @@ var Asset = {
 	javascript: function(source, properties){
 		if (!properties) properties = {};
 
-		var script = new Element('script', {src: source, type: 'text/javascript'}),
+		var script = new Element('script', {src: source}),
 			doc = properties.document || document,
 			loaded = 0,
 			loadEvent = properties.onload || properties.onLoad;


### PR DESCRIPTION
It seems a waste of bytes to me, but I don't know if there are good reasons to keep the type attribute?
