### PR TITLE
Form.Validator fixes: stopOnFailure and Element.validate

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -172,8 +172,7 @@ Form.Validator = new Class({
 	},
 
 	onSubmit: function(event){
-		if (!this.validate(event) && event) event.preventDefault();
-		else this.reset();
+		if (this.validate(event)) this.reset();
 	},
 
 	reset: function(){
@@ -508,7 +507,7 @@ Element.implement({
 
 	validate: function(options){
 		if (options) this.set('validator', options);
-		return this.get('validator', options).validate();
+		return this.get('validator').validate();
 	}
 
 });


### PR DESCRIPTION
- the stopOnFailure preference was ignored when evaluateOnSubmit was enabled. Because this logic exists in the validate method there's no reason to prevent the event in the onSubmit method (which invokes this.validate)
- the getter in Element.validate still passed in a default options argument. This resulted in an error because the chained .validate() method was being called on the result of a multi-get return.
