### PR TITLE
Form.Validator element.get('validator') still used options as second argument

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -184,7 +184,9 @@ Form.Validator = new Class({
 	validate: function(event){
 		var result = this.getFields().map(function(field){
 			return this.validateField(field, true);
-		}, this).every(function(v){ return v;});
+		}, this).every(function(v){
+			return v;
+		});
 		this.fireEvent('formValidate', [result, this.element, event]);
 		if (this.options.stopOnFailure && !result && event) event.preventDefault();
 		return result;
@@ -209,7 +211,7 @@ Form.Validator = new Class({
 				if (className && !this.test(className, field)) validatorsFailed.include(className);
 			}, this);
 			passed = validatorsFailed.length === 0;
-			if (validators && !this.hasValidator(field,'warnOnly')){
+			if (validators && !this.hasValidator(field, 'warnOnly')){
 				if (passed){
 					field.addClass('validation-passed').removeClass('validation-failed');
 					this.fireEvent('elementPass', [field]);
@@ -239,7 +241,7 @@ Form.Validator = new Class({
 		field = document.id(field);
 		if ((this.options.ignoreHidden && !field.isVisible()) || (this.options.ignoreDisabled && field.get('disabled'))) return true;
 		var validator = this.getValidator(className);
-		warn = warn != null ? warn : false;
+		if (warn != null) warn = false;
 		if (this.hasValidator(field, 'warnOnly')) warn = true;
 		var isValid = this.hasValidator(field, 'ignoreValidation') || (validator ? validator.test(field) : true);
 		if (validator && field.isVisible()) this.fireEvent('elementValidate', [isValid, field, className, warn]);

--- a/Specs/1.3/Forms/Form.Validator.js
+++ b/Specs/1.3/Forms/Form.Validator.js
@@ -38,17 +38,32 @@ describe('Form.Validator', function(){
 
 	});
 
-/*
+
 	describe('Element.validate method', function(){
-		var form = new Element('form').adopt(
-			new Element('input', {
-				'class': 'minLength:10',
-				value: 'toShort'
-			})
-		);
-		expect(form.validate()).toEqual(false);
+		it('should return false if the form is not valid', function(){
+			var form = new Element('form').adopt(
+				new Element('input', {
+					'class': 'minLength:10',
+					value: 'toShort'
+				})
+			);
+			expect(form.validate({ignoreHidden: false})).toEqual(false);
+		});
 	});
-*/
+
+	describe('Warnings', function(){
+
+		it('should still validate the form when there is a warning', function(){
+			var form = new Element('form').adopt(
+				new Element('input', {
+					'class': 'warn-required'
+				})
+			);
+			expect(form.validate({ignoreHidden: false})).toEqual(true);
+		});
+	
+	});
+
 	describe('onElementPass', function(){
 
 		var form, select;


### PR DESCRIPTION
That and some other small fixes.
Hope we can still include this.
