### PR TITLE
Fix 527 - Number.format modifies options argument

### DIFF
--- a/Source/Types/Number.Format.js
+++ b/Source/Types/Number.Format.js
@@ -12,7 +12,7 @@ authors:
 
 requires:
   - Core/Number
-  - /Locale.en-US.Number
+  - Locale.en-US.Number
 
 provides: [Number.Extras]
 
@@ -25,7 +25,7 @@ Number.implement({
 	format: function(options){
 		// Thanks dojo and YUI for some inspiration
 		var value = this;
-		if (!options) options = {};
+		options = options ? Object.clone(options) : {};
 		var getOption = function(key){
 			if (options[key] != null) return options[key];
 			return Locale.get('Number.' + key);
@@ -38,10 +38,10 @@ Number.implement({
 			decimals = getOption('decimals');
 
 		if (negative){
-			var negativeLocale = Locale.get('Number.negative') || {};
+			var negativeLocale = getOption('negative') || {};
 			if (negativeLocale.prefix == null && negativeLocale.suffix == null) negativeLocale.prefix = '-';
-			Object.each(negativeLocale, function(value, key){
-				options[key] = (key == 'prefix' || key == 'suffix') ? (getOption(key) + value) : value;
+			['prefix', 'suffix'].each(function(key){
+				if (negativeLocale[key]) options[key] = getOption(key) + negativeLocale[key];
 			});
 
 			value = -value;

--- a/Specs/1.3/Types/Number.Format.js
+++ b/Specs/1.3/Types/Number.Format.js
@@ -1,12 +1,12 @@
 /*
-Script: Number.Extras.js
-	Specs for Number.Extras.js
+Script: Number.Format.js
+	Specs for Number.Format.js
 
 License:
 	MIT-style license.
 */
 
-describe('Number.Extras', function(){
+describe('Number.Format', function(){
 
 	describe('Number.format', function(){
 
@@ -24,6 +24,12 @@ describe('Number.Extras', function(){
 
 		it('should format a negative number', function(){
 			expect((-20000).format()).toEqual('-20,000');
+		});
+
+		it('should format a negative number with a special minus sign', function(){
+			expect((-20000).format({negative: {prefix:'_'}})).toEqual('_20,000');
+			expect((-20000).format({negative: {suffix:'_'}})).toEqual('20,000_');
+			expect((-20000).format({negative: {prefix:'_', suffix: '^'}})).toEqual('_20,000^');
 		});
 
 		it('should format with the right decimals', function(){
@@ -69,6 +75,12 @@ describe('Number.Extras', function(){
 
 		it('should format percentage', function(){
 			expect((50).formatPercentage()).toEqual('50.00%');
+		});
+
+		it('should not change the options object', function(){
+			var options = {prefix: 'foo'};
+			(-3).format(options);
+			expect(options.prefix).toEqual('foo');
 		});
 
 	});


### PR DESCRIPTION
Fixes https://mootools.lighthouseapp.com/projects/24057/tickets/527

the options argument was modified inside Number.format, using Object.clone to fix this.
