### PR TITLE
Drag was broken when equality evaluation was written as an assignment.

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -111,8 +111,8 @@ var Drag = new Class({
 
 		var styles = this.element.getStyles('left', 'right', 'top', 'bottom');
 		this._invert = {
-			x: options.modifiers.x == 'left' && styles.left == 'auto' && !isNaN(styles.right.toInt()) && (options.modifiers.x = 'right'),
-			y: options.modifiers.y == 'top' && styles.top == 'auto' && !isNaN(styles.bottom.toInt()) && (options.modifiers.y = 'bottom')
+			x: options.modifiers.x == 'left' && styles.left == 'auto' && !isNaN(styles.right.toInt()) && (options.modifiers.x == 'right'),
+			y: options.modifiers.y == 'top' && styles.top == 'auto' && !isNaN(styles.bottom.toInt()) && (options.modifiers.y == 'bottom')
 		};
 
 		var z, coordinates;


### PR DESCRIPTION
When the equality was checked it was actually assigned as false when it was supposed to be a string value throughout. This caused the visual effect of the following after creating a draggable element.

The element when dragged the first time would move with the mouse. But, then the second time the drag was tried, the dragged element would have inverted direction to the direction of the mouse movement. So, if the mouse moved down, then the element moved up.
