### PR TITLE
Drag for elements with right/bottom positioning

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -109,12 +109,6 @@ var Drag = new Class({
 		var limit = options.limit;
 		this.limit = {x: [], y: []};
 
-		var styles = this.element.getStyles('left', 'right', 'top', 'bottom');
-		this._invert = {
-			x: options.modifiers.x == 'left' && styles.left == 'auto' && !isNaN(styles.right.toInt()) && (options.modifiers.x = 'right'),
-			y: options.modifiers.y == 'top' && styles.top == 'auto' && !isNaN(styles.bottom.toInt()) && (options.modifiers.y = 'bottom')
-		};
-
 		var z, coordinates;
 		for (z in options.modifiers){
 			if (!options.modifiers[z]) continue;
@@ -131,7 +125,6 @@ var Drag = new Class({
 			else this.value.now[z] = this.element[options.modifiers[z]];
 
 			if (options.invert) this.value.now[z] *= -1;
-			if (this._invert[z]) this.value.now[z] *= -1;
 
 			this.mouse.pos[z] = event.page[z] - this.value.now[z];
 
@@ -181,7 +174,6 @@ var Drag = new Class({
 			this.value.now[z] = this.mouse.now[z] - this.mouse.pos[z];
 
 			if (options.invert) this.value.now[z] *= -1;
-			if (this._invert[z]) this.value.now[z] *= -1;
 
 			if (options.limit && this.limit[z]){
 				if ((this.limit[z][1] || this.limit[z][1] === 0) && (this.value.now[z] > this.limit[z][1])){

--- a/Tests/Drag/Drag.Move_(position_right_bottom).html
+++ b/Tests/Drag/Drag.Move_(position_right_bottom).html
@@ -1,0 +1,41 @@
+
+<style>
+
+#wrapper {
+	border: 1px solid #555;
+	background: #DDD;
+	position: relative;
+	height: 300px;
+	width: 300px;
+}
+
+#wrapper div {
+	cursor: pointer;
+	position: absolute;
+}
+
+</style>
+
+<p>
+	You should be able to drag all four elements around, even when they are positioned with bottom or right.
+</p>
+
+<div id="wrapper">
+
+	<div id="topLeft" style="top:0; left:0;">topLeft</div>
+	<div id="topRight" style="top:20px; right:20px;">topRight</div>
+	<div id="bottomLeft" style="bottom:0; left:0;">bottomLeft</div>
+	<div id="bottomRight" style="bottom:0; right:0;">bottomRight</div>
+
+</div>
+
+<script src="/depender/build?require=More/Drag.Move"></script>
+
+<script>
+
+new Drag('topLeft');
+new Drag('topRight');
+new Drag('bottomLeft');
+new Drag('bottomRight');
+
+</script>


### PR DESCRIPTION
Alternative solution for https://github.com/mootools/mootools-more/pull/217
and this jsfiddle: http://jsfiddle.net/doubleTap/c79ez/3/

This code was originally added for webkit when it would return "auto", but there is another check which was later added in case getStyle wouldn't return something with pixels, so it's not necessary anymore and it caused the above mentioned bug.

I added another test and tested all existing tests and they all work fine!
