### PR TITLE
Fix #528: Chain.Wait

### DIFF
--- a/Source/Class/Chain.Wait.js
+++ b/Source/Class/Chain.Wait.js
@@ -29,6 +29,7 @@ provides: [Chain.Wait]
 		wait: function(duration){
 			return this.chain(function(){
 				this.callChain.delay(duration == null ? 500 : duration, this);
+				return this;
 			}.bind(this));
 		}
 	};

--- a/Specs/1.3/Class/Chain.Wait.js
+++ b/Specs/1.3/Class/Chain.Wait.js
@@ -47,4 +47,22 @@ describe('Chain.Wait', function(){
 
 	});
 
+	it('should not break the chainComplete event in Fx', function(){
+		var count = 0;
+		new Fx({
+			link: 'chain',
+			onChainComplete: function(){
+				count++;
+			},
+			duration: 50
+		}).start(0, 1).wait(40).start(1, 0);
+
+		waits(500);
+
+		runs(function(){
+			expect(count).toEqual(1);
+		});
+
+	});
+
 });


### PR DESCRIPTION
In combination with Fx, the chainComplete event was called twice, as shown in this jsfiddle: http://jsfiddle.net/fQpGQ/

However the chain is only complete one time. To fix this the wait method can return a truthy value so the Fx:stop method will wait till the chain is really complete.

LH: https://mootools.lighthouseapp.com/projects/24057/tickets/528
