### PR TITLE
Fixes #557 - Element.set/get for Form.Request no longer work in 1.3

### DIFF
--- a/Docs/Forms/Form.Request.md
+++ b/Docs/Forms/Form.Request.md
@@ -42,6 +42,23 @@ Form.Request and Form.Validator {#Form-Request:Form-Validator}
 
 *Form.Request* integrates with [Form.Validator][] to prevent the ajax being sent if the validation fails. It retrieves the *Form.Validator* instance from the form, so all that is required is that you instantiate the *Form.Validator* before you instantiate the instance of *Fudpate*. If the instance of *Form.Validator* has the *stopOnFailure* option set to *true* (the default) then *Form.Request* will not send the ajax request if the validator fails.
 
+Form.Request Method: setTarget {#Form-Request:setTarget}
+--------------------------------------
+
+Changes the target that the instance will update with the Request response.
+
+### Syntax
+
+	myFormRequest.setTarget(newTarget);
+
+### Arguments
+
+1. newTarget - (*mixed*) An Element or the string id of an Element to update with the response.
+
+### Returns
+
+* (*object*) - This instance of [Form.Request][]
+
 Form.Request Method: send {#Form-Request:send}
 --------------------------------------
 
@@ -81,6 +98,39 @@ Attaches the Form.Request to the form (enabling the ajax). Note that this is don
 
 * (*object*) - This instance of [Form.Request][]
 
+Type: Element {#Element}
+==========================
+
+Extends the [Element][] Type with a reference to its [Form.Request][] instance and a method to create one.
+
+Element Method: formRequest {#Element:formRequest}
+-------------------------------------
+
+Creates a new instance of [Form.Request][] and calls its *send* method.
+
+### Syntax
+
+	$(element).formRequest(update, options);
+
+### Arguments
+
+* update - (*mixed*) An Element or the string id of an Element to update with the response.
+* options - (*object*) a key/value set of options. See [Form.Request:options][].
+
+### Returns
+
+* (*element*) This Element.
+
+### Example
+
+	$(element).formRequest($('myDiv'), { requestOptions: {useSpinner: false } });
+
+Element property: form.request {#Element:form.request}
+------------------------------------------------
+
+### Syntax
+
+	myForm.retrieve('form.request'); //the instance of Form.Request for the element
 
 [Chain]: /core/Class/Class.Extras#Chain
 [Events]: /core/Class/Class.Extras#Events
@@ -88,3 +138,4 @@ Attaches the Form.Request to the form (enabling the ajax). Note that this is don
 [Class.Occlude]: /more/Class/Class.Occlude
 [Form.Request]: #Form-Request
 [Form.Validator]: /more/Forms/Form.Validator#Form-Validator
+[Element]: /core/Type/Element

--- a/Source/Forms/Form.Request.Append.js
+++ b/Source/Forms/Form.Request.Append.js
@@ -54,11 +54,11 @@ Form.Request.Append = new Class({
 						}
 					}).adopt(kids);
 				}
-				container.inject(this.update, this.options.inject);
+				container.inject(this.target, this.options.inject);
 				if (this.options.requestOptions.evalScripts) Browser.exec(javascript);
 				this.fireEvent('beforeEffect', container);
 				var finish = function(){
-					this.fireEvent('success', [container, this.update, tree, elements, html, javascript]);
+					this.fireEvent('success', [container, this.target, tree, elements, html, javascript]);
 				}.bind(this);
 				if (this.options.useReveal){
 					container.set('reveal', this.options.revealOptions).get('reveal').chain(finish);
@@ -71,6 +71,7 @@ Form.Request.Append = new Class({
 				this.fireEvent('failure', xhr);
 			}.bind(this)
 		});
+		this.attachReset();
 	}
 
 });

--- a/Tests/Forms/Form.Request.html
+++ b/Tests/Forms/Form.Request.html
@@ -17,6 +17,12 @@
 	</div>
 </div>
 
+<div style="position: relative; margin-top: 10px">
+	<div id="update2" style="padding: 10px; width: 200px; border: 1px solid black; height: 100px; overflow:hidden;">
+		<a id="update2link">If you click this link, the first form should submit and update this box.</a>
+	</div>
+</div>
+
 <script src="/depender/build?require=More/Form.Request,More/Spinner"></script>
 <script type="text/javascript">
 	new Form.Request($('test'), $('update'), {
@@ -29,5 +35,15 @@
 			spinnerTarget: $('update'),
 			url: '/ajax_html_echo/'
 		}
+	});
+	$('update2link').addEvent('click', function(){
+		$('test').formUpdate('update2', {
+			extraData: {
+				html: 'Success!'
+			},
+			requestOptions: {
+				spinnerTarget: $('update2')
+			}
+		});
 	});
 </script>


### PR DESCRIPTION
https://mootools.lighthouseapp.com/projects/24057/tickets/557
- Removed set/get props since they just don't make sense if you can't pass more than one argument.
- Updated the Element method formRequest to work without them.
- Made it possible to reassign the target for the Form.Request at any point.
- Added demo of this behavior.
- Added docs for the Element method and the stored reference.
