### PR TITLE
Hotfix for when HtmlTable.Sort and HtmlTable.Select are used simultaneously

### DIFF
--- a/Source/Interface/HtmlTable.Select.js
+++ b/Source/Interface/HtmlTable.Select.js
@@ -47,13 +47,12 @@ HtmlTable = Class.refactor(HtmlTable, {
 
 		this.selectedRows = new Elements();
 
-		this.bound = {
-			mouseleave: this.mouseleave.bind(this),
-			clickRow: this.clickRow.bind(this),
-			activateKeyboard: function(){
-				if (this.keyboard && this.selectEnabled) this.keyboard.activate();
-			}.bind(this)
-		};
+		if (!this.bound) this.bound = {};
+		this.bound.mouseleave = this.mouseleave.bind(this);
+		this.bound.clickRow = this.clickRow.bind(this);
+		this.bound.activateKeyboard = function(){
+			if (this.keyboard && this.selectEnabled) this.keyboard.activate();
+		}.bind(this);
 
 		if (this.options.selectable) this.enableSelect();
 	},
@@ -310,7 +309,7 @@ HtmlTable = Class.refactor(HtmlTable, {
 					clearTimeout(timer);
 					held = false;
 				};
-				
+
 				this.keyboard.addEvents({
 					'keydown:shift+up': move(-1),
 					'keydown:shift+down': move(1),

--- a/Source/Interface/HtmlTable.Sort.js
+++ b/Source/Interface/HtmlTable.Sort.js
@@ -51,9 +51,8 @@ HtmlTable = Class.refactor(HtmlTable, {
 		this.previous.apply(this, arguments);
 		if (this.occluded) return this.occluded;
 		this.sorted = {index: null, dir: 1};
-		this.bound = {
-			headClick: this.headClick.bind(this)
-		};
+		if (!this.bound) this.bound = {};
+		this.bound.headClick = this.headClick.bind(this);
 		this.sortSpans = new Elements();
 		if (this.options.sortable){
 			this.enableSort();


### PR DESCRIPTION
Fixes this.bound getting overridden by HtmlTable.Select and therefore breaking this.bound.headClick (breaks sorting completely).

Bug introduced in commit fcc9477fb560f6cc347a518fa32565debc9dc9d4

@fat offered to update the tests to cover this, due to my lack of time
