### PR TITLE
Fix for #572 Fx.Slide not working properly on absolute-positioned elements

### DIFF
--- a/Source/Fx/Fx.Slide.js
+++ b/Source/Fx/Fx.Slide.js
@@ -39,7 +39,7 @@ Fx.Slide = new Class({
 		options = this.options;
 
 		var wrapper = element.retrieve('wrapper'),
-			styles = element.getStyles('margin', 'position', 'overflow');
+			styles = element.getStyles('margin', 'position', 'overflow', 'top', 'right', 'bottom', 'left');
 
 		if (options.hideOverflow) styles = Object.append(styles, {overflow: 'hidden'});
 		if (options.wrapper) wrapper = document.id(options.wrapper).setStyles(styles);


### PR DESCRIPTION
https://mootools.lighthouseapp.com/projects/24057/tickets/572-fxslide-not-working-properly-on-absolute-positioned-elements
