### PR TITLE
Add WAI-ARIA support to Spinner.

### DIFF
--- a/Source/Interface/Spinner.js
+++ b/Source/Interface/Spinner.js
@@ -90,6 +90,7 @@ var Spinner = new Class({
 			return this;
 		}
 
+		this.target.set('aria-busy', 'true');
 		this.active = true;
 
 		return this.parent(noFx);
@@ -124,7 +125,10 @@ var Spinner = new Class({
 			this.callChain.delay(20, this);
 			return this;
 		}
+
+		this.target.set('aria-busy', 'false');
 		this.active = true;
+
 		return this.parent(noFx);
 	},
 


### PR DESCRIPTION
aria-busy is helpful if one changes multiple things inside a container that is set to a aria-live=polite or aria-live=assertive. If aria-live isn't set or set to off it has no effect - but also no harm.
