### PR TITLE
Number.Format formatPercentage to accept the number of decimals

### DIFF
--- a/Source/Types/Number.Format.js
+++ b/Source/Types/Number.Format.js
@@ -97,7 +97,7 @@ Number.implement({
 	formatPercentage: function(decimals){
 		var locale = Locale.get('Number.percentage') || {};
 		if (locale.suffix == null) locale.suffix = '%';
-		local.decimals = typeOf(decimals) === 'number' ? decimals : locale.decimals;
+		if (decimals != null) local.decimals = decimals;
 
 		return this.format(locale);
 	}


### PR DESCRIPTION
Fixing Number.Format formatPercentage to accept the number of decimals to show as a parameter: makes no sense to have the # of decimal places to show just be based on the locale as it's just a display formatting setting.
