### PR TITLE
Fixes #547 - Fixes the onLoad event for Asset.css so it should work cross

### DIFF
--- a/Docs/Utilities/Assets.md
+++ b/Docs/Utilities/Assets.md
@@ -52,6 +52,7 @@ Injects a css file in the page.
 
 1. source     - (*string*) The path of the CSS file.
 2. properties - (*object*) Some additional attributes you might want to add to the link Element; this is the same as the second argument you might pass to including the Element constructor. For instance you might specify a title attribute or perhaps an id.
+   - onLoad   - (*function*) A function that will be invoked when the CSS is loaded.
    - document - (*object*, defaults to `document`) The document which the link element should be injected in.
 
 

--- a/Source/Utilities/Assets.js
+++ b/Source/Utilities/Assets.js
@@ -56,15 +56,31 @@ var Asset = {
 			type: 'text/css',
 			href: source
 		});
-
-		var load = properties.onload || properties.onLoad,
-			doc = properties.document || document;
-
-		delete properties.onload;
-		delete properties.onLoad;
+		
+		var doc = properties.document || document;
 		delete properties.document;
 
-		if (load) link.addEvent('load', load);
+		var load = properties.onload || properties.onLoad;
+		delete properties.onload;
+		delete properties.onLoad;
+		if (load){
+			var loaded = 0, s = 'sheet', r = 'cssRules';
+			var fn = function(){
+				if (!loaded++) load.call(link);
+			};
+			var check = function(){
+				if (link.styleSheet) return;
+				// cssready technique by Diego Perini: http://javascript.nwbox.com/CSSReady/cssready.html
+				try {
+					if (link[s] && link[s][r]) return fn();
+				} catch (e){}
+				if (!loaded) setTimeout(check, 50);
+
+			};
+			link.addEvent('load', fn);
+			setTimeout(check, 0);
+		}
+
 		return link.set(properties).inject(doc.head);
 	},
 

--- a/Tests/Interactive/Utilities/Assets.html
+++ b/Tests/Interactive/Utilities/Assets.html
@@ -4,6 +4,8 @@
 
 <img border="0" alt="MooTools" src="/asset/more/mootools.png" title="MooTools" rel="The best damn JS framework on Earth." id="moologo"/>
 
+<div id="cssonloadtest">The onload should fire after the big background images has been loaded</div>
+
 <hr />
 <p>
 	A MooTools logo should load in the box below.
@@ -29,6 +31,11 @@
 	list-style: disc;
 }
 
+#cssonloadtest {
+	padding: 10px;
+	border: 4px solid #f99;
+}
+
 </style>
 
 <div id="imgtest2"></div>
@@ -43,7 +50,12 @@
 <script src="/depender/build?require=More/Assets"></script>
 <script>
 
-	Asset.css('/asset/more/Assets.css.test.css');
+	Asset.css('/asset/more/Assets.css.test.css', {
+		onload: function(){
+			$('cssonloadtest').set('text', 'Loaded');
+			$('cssonloadtest').style.borderColor = 'green';
+		}
+	});
 	Asset.image('/asset/more/mootools.png', {
 		onLoad: function(){
 			this.inject('imgtest');

--- a/Tests/Specs/1.3/Utilities/Assets.js
+++ b/Tests/Specs/1.3/Utilities/Assets.js
@@ -43,9 +43,9 @@ describe('Assets', function(){
 			var myCSS = Asset.css('../assets/Assets.css.test.css', {
 				id: 'myStyle',
 				title: 'myStyle',
-				events: {load: function(){
+				onload: function(){
 					load(this);
-				}}
+				}
 			});
 
 			waits(500);
@@ -53,8 +53,7 @@ describe('Assets', function(){
 			runs(function(){
 				expect(myCSS.get('tag')).toEqual('link');
 				expect(myCSS.id).toEqual('myStyle');
-				// Current implementation of assets uses the load event which only works in IE/Opera
-				// expect(load).toHaveBeenCalledWith(myCSS);
+				expect(load).toHaveBeenCalledWith(myCSS);
 				myCSS.destroy();
 			});
 


### PR DESCRIPTION
Fixes #547 - Fixes the onLoad event for Asset.css so it should work cross browser

https://mootools.lighthouseapp.com/projects/24057/tickets/547

Thanks to:
- Diego Perini's CSS Ready: http://javascript.nwbox.com/CSSReady/cssready.html
- http://www.yearofmoo.com/2011/07/mootools-asset-stylesheet-onload-event-patch.html

Tested in:
- Firefox 5
- Chrome 13
- IE6-9
- Opera 11.50
