### PR TITLE
Fixed Scroller class issue when passing 'window' as element.

### DIFF
--- a/Source/Interface/Scroller.js
+++ b/Source/Interface/Scroller.js
@@ -85,7 +85,7 @@ var Scroller = new Class({
 	scroll: function(){
 		var size = this.element.getSize(),
 			scroll = this.element.getScroll(),
-			pos = this.element != this.docBody ? this.element.getOffsets() : {x: 0, y:0},
+			pos = ((this.element != this.docBody) && (this.element != window)) ? element.getOffsets() : {x: 0, y: 0},
 			scrollSize = this.element.getScrollSize(),
 			change = {x: 0, y: 0},
 			top = this.options.area.top || this.options.area,


### PR DESCRIPTION
Pull request requested on issue [#1012](https://github.com/mootools/mootools-more/issues/1012)
