### PR TITLE
Easy way to add a class name to a clone.

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -31,6 +31,7 @@ var Sortables = new Class({
 		onComplete: function(element){},*/
 		opacity: 1,
 		clone: false,
+		cloneClass: 'clone',
 		revert: false,
 		handle: false,
 		dragOptions: {}/*<1.2compat>*/,
@@ -114,7 +115,7 @@ var Sortables = new Class({
 			width: element.getStyle('width')
 		}).addEvent('mousedown', function(event){
 			element.fireEvent('mousedown', event);
-		});
+		}).addClass(this.options.cloneClass || '');
 		//prevent the duplicated radio inputs from unchecking the real one
 		if (clone.get('html').test('radio')){
 			clone.getElements('input[type=radio]').each(function(input, i){


### PR DESCRIPTION
A common addition to clones, is the ability to differentiate the clone from the original. In my case, the navigation item needs to have the "selected" class name styles removed, so if I add another class, it can be done properly.
