### PR TITLE
Increasing the timeout for the pause pseudo; it's failing for me intermittently in automated test (firefox).

### DIFF
--- a/Tests/Specs/1.3/Class/Events.Pseudos.js
+++ b/Tests/Specs/1.3/Class/Events.Pseudos.js
@@ -123,7 +123,7 @@ describe('Events.Pseudos', function(){
 				expect(fn.callCount).toEqual(1);
 			});
 
-			waits(300);
+			waits(400);
 
 			runs(function(){
 				// the delayed event should have fired


### PR DESCRIPTION
Increasing the timeout for the pause pseudo; it's failing for me intermittently in automated test (firefox).
