### PR TITLE
HtmlTable method: empty fails on empty table

### DIFF
--- a/Source/Interface/HtmlTable.Select.js
+++ b/Source/Interface/HtmlTable.Select.js
@@ -109,14 +109,6 @@ HtmlTable = Class.refactor(HtmlTable, {
 		return this.selectedRows.contains(row);
 	},
 
-	getSelected: function(){
-		return this.selectedRows;
-	},
-
-	getSelected: function(){
-		return this.selectedRows;
-	},
-
 	serialize: function(){
 		var previousSerialization = this.previous.apply(this, arguments) || {};
 		if (this.options.selectable){


### PR DESCRIPTION
Calling myTable.empty(); on an already empty HtmlTable you get this error

`Uncaught TypeError: Cannot call method 'isDisplayed' of undefined`

tracked it to the selectRange function for loop

```
for (var i = startRow; i <= endRow; i++){
            if (this.options.selectHiddenRows || rows[i].isDisplayed()) this[method](rows[i], true);
        }
```

This commit addresses the issue...

All the best
Daniel
