### PR TITLE
Fixing odd IE bug where this.text (created with the Element constructor)

### DIFF
--- a/Source/Forms/OverText.js
+++ b/Source/Forms/OverText.js
@@ -191,7 +191,7 @@ var OverText = new Class({
 	},
 
 	show: function(){
-		if (this.text && !this.text.isDisplayed()){
+		if (document.id(this.text) && !this.text.isDisplayed()){
 			this.text.show();
 			this.reposition();
 			this.fireEvent('textShow', [this.text, this.element]);


### PR DESCRIPTION
Fixing odd IE bug where this.text (created with the Element constructor) is not extended. WTF?
