### PR TITLE
Sortables to prevent start drag for <select> elements too

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -148,7 +148,7 @@ var Sortables = new Class({
 		if (
 			!this.idle ||
 			event.rightClick ||
-			['button', 'input', 'a', 'textarea'].contains(event.target.get('tag'))
+			['button', 'input', 'a', 'textarea', 'select'].contains(event.target.get('tag'))
 		) return;
 
 		this.idle = false;


### PR DESCRIPTION
In Sortables.start() function,

can we also prevent dragging if the event target is a select element ?

Best Regards.
