### PR TITLE
Keyboard.removeEvents() doesn't work

### DIFF
--- a/Source/Interface/Keyboard.js
+++ b/Source/Interface/Keyboard.js
@@ -57,7 +57,7 @@ provides: [Keyboard]
 		},
 
 		removeEvent: function(type, fn){
-			return this.parent(Keyboard.parse(type, this.options.defaultEventType, this.options.nonParsedEvents), fn);
+			return this.parent(type, fn);
 		},
 
 		toggleActive: function(){


### PR DESCRIPTION
Keyboard.addEvent calls parent() with a parsed event type. When removeEvents is called, it will call removeEvent with the already parsed event type. We cannot call Keyboard.parse() inside of removeEvent because then we would be parsing an already parsed event type.

I don't really like my fix, as it means that an argument to Keyboard.addEvent() is not a valid argument to Keyboard.removeEvent. I'm not sure what the best fix to this problem is, however.
