### PR TITLE
[Date] set higher priority at new defined parsers

### DIFF
--- a/Source/Types/Date.js
+++ b/Source/Types/Date.js
@@ -408,7 +408,7 @@ Date.extend({
 	//</1.2compat>
 
 	defineParser: function(pattern){
-		parsePatterns.push((pattern.re && pattern.handler) ? pattern : build(pattern));
+		parsePatterns.splice(0,0,(pattern.re && pattern.handler) ? pattern : build(pattern));
 		return this;
 	},
 


### PR DESCRIPTION
Using splice(0,0,… when adding parser allow to set priority at new defined parsers.

e.g. if I add a parser for European dates

Date.defileParser("%d/%m/%Y");

without this change all strings with the day under 13th of month, like 09/02/2012, will be parsed in the american date, the example will be 2 September 2012, not 9 February 2012.
