### PR TITLE
Removing redundant multiple getSelected methods in HtmlTable.Select

### DIFF
--- a/Source/Types/Object.Extras.js
+++ b/Source/Types/Object.Extras.js
@@ -32,12 +32,10 @@ var hasOwnProperty = Object.prototype.hasOwnProperty;
 Object.extend({
 
 	getFromPath: function(source, parts){
-		if (source != null) {
-			if (typeof parts == 'string') parts = parts.split('.');
-			for (var i = 0, l = parts.length; i < l; i++){
-				if (source != null && hasOwnProperty.call(source, parts[i])) source = source[parts[i]];
-				else return null;
-			}
+		if (typeof parts == 'string') parts = parts.split('.');
+		for (var i = 0, l = parts.length; i < l; i++){
+			if (hasOwnProperty.call(source, parts[i])) source = source[parts[i]];
+			else return null;
 		}
 		return source;
 	},


### PR DESCRIPTION
There are 3 copies of the exact same method with exactly the same body in the HtmlTable.Select file.

Unless I'm missing something extraordinarily complex or simple, this is almost certainly an error.
