### PR TITLE
Fixes problem in IE where offsetParent was null, putting after null chec...

### DIFF
--- a/Source/Element/Element.Position.js
+++ b/Source/Element/Element.Position.js
@@ -69,9 +69,10 @@ var local = Element.Position = {
 			offsetParent = element.measure(function(){
 				return document.id(this.getOffsetParent());
 			}),
-			parentScroll = offsetParent.getScroll();
+			parentScroll;
 
 		if (!offsetParent || offsetParent == element.getDocument().body) return;
+		parentScroll = offsetParent.getScroll();
 		parentOffset = offsetParent.measure(function(){
 			var position = this.getPosition();
 			if (this.getStyle('position') == 'fixed'){


### PR DESCRIPTION
...k. Also avoids an unnecessary variable assignment if we are returning out of the function.
