### PR TITLE
Configure undraggable tags in Sortables.

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -36,7 +36,8 @@ var Sortables = new Class({
 		dragOptions: {}/*<1.2compat>*/,
 		snap: 4,
 		constrain: false,
-		preventDefault: false
+		preventDefault: false,
+		unDraggableTags: ['button', 'input', 'a', 'textarea', 'select', 'option']
 		/*</1.2compat>*/
 	},
 
@@ -148,7 +149,7 @@ var Sortables = new Class({
 		if (
 			!this.idle ||
 			event.rightClick ||
-			['button', 'input', 'a', 'textarea', 'select', 'option'].contains(event.target.get('tag'))
+			this.options.unDraggableTags.contains(event.target.get('tag'))
 		) return;
 
 		this.idle = false;


### PR DESCRIPTION
The input, button, a, textarea, select and option tags aren't draggable
when using Sortables. This patch adds an unDraggableTags option that can
be passed to Sortables to override the above list, allowing you to drag
a container element even when you click on one of the (undraggable)
elements within it.
