### PR TITLE
fix for #1133 so that IE9+ which has readystatechange for legacy

### DIFF
--- a/Source/Utilities/Assets.js
+++ b/Source/Utilities/Assets.js
@@ -35,7 +35,7 @@ var Asset = {
 		delete properties.document;
 
 		if (load){
-			if (typeof script.onreadystatechange != 'undefined'){
+			if (!script.addEventListener){
 				script.addEvent('readystatechange', function(){
 					if (['loaded', 'complete'].contains(this.readyState)) load.call(this);
 				});


### PR DESCRIPTION
flipped feature check to take advantage of addEventListener for `load` instead, if available - ie9 reports readystatechange on the element despite being able to add normal events.
