### PR TITLE
Creating a new Color with explicit type='hex' will cast color twice

### DIFF
--- a/Source/Utilities/Color.js
+++ b/Source/Utilities/Color.js
@@ -36,13 +36,11 @@ var Color = this.Color = new Type('Color', function(color, type){
 		else color = color.hexToRgb(true);
 	}
 	type = type || 'rgb';
-	switch (type){
-		case 'hsb':
-			var old = color;
-			color = color.hsbToRgb();
-			color.hsb = old;
-		break;
-		case 'hex': color = color.hexToRgb(true); break;
+	if (type == 'hsb')
+	{
+		var old = color;
+		color = color.hsbToRgb();
+		color.hsb = old;
 	}
 	color.rgb = color.slice(0, 3);
 	color.hsb = color.hsb || color.rgbToHsb();


### PR DESCRIPTION
Fixes #1172
