### PR TITLE
Mask.inject "where" fix

### DIFF
--- a/Source/Interface/Mask.js
+++ b/Source/Interface/Mask.js
@@ -81,7 +81,7 @@ var Mask = new Class({
 	},
 
 	inject: function(target, where){
-		where = where || (this.options.inject ? this.options.inject.where : '') || this.target == document.body ? 'inside' : 'after';
+		where = where || (this.options.inject ? this.options.inject.where : '') || (this.target == document.body ? 'inside' : 'after');
 		target = target || (this.options.inject && this.options.inject.target) || this.target;
 
 		this.element.inject(target, where);


### PR DESCRIPTION
Fixed the Mask.inject function to inject at the right position relative to the target. The "where" was wrongly determined
