### PR TITLE
Sortables: only check unDraggableTags if no handle

### DIFF
--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -149,7 +149,7 @@ var Sortables = new Class({
 		if (
 			!this.idle ||
 			event.rightClick ||
-			this.options.unDraggableTags.contains(event.target.get('tag'))
+			(!this.options.handle && this.options.unDraggableTags.contains(event.target.get('tag')))
 		) return;
 
 		this.idle = false;


### PR DESCRIPTION
Whatever you point your handle to, it should always be the handle, even if it is one of the unDraggableTags.
