### PR TITLE
Script error in setOffsetOption() if !offsetParent

### DIFF
--- a/Source/Element/Element.Position.js
+++ b/Source/Element/Element.Position.js
@@ -66,12 +66,14 @@ var local = Element.Position = {
 
 	setOffsetOption: function(element, options){
 		var parentOffset = {x: 0, y: 0},
+			parentScroll = {x: 0, y: 0},
 			offsetParent = element.measure(function(){
 				return document.id(this.getOffsetParent());
-			}),
-			parentScroll = offsetParent.getScroll();
+			});
 
 		if (!offsetParent || offsetParent == element.getDocument().body) return;
+		
+		parentScroll = offsetParent.getScroll();
 		parentOffset = offsetParent.measure(function(){
 			var position = this.getPosition();
 			if (this.getStyle('position') == 'fixed'){


### PR DESCRIPTION
`offsetParent.getScroll()` had thrown an error if `!offsetParent`. Because there is already an if condition with return, its moved after that condition.
