### PR TITLE
Update Form.Validator.Extras.js

### DIFF
--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -118,7 +118,7 @@ Form.Validator.addAllThese([
 
 	['validate-match', {
 		errorMsg: function(element, props){
-			return Form.Validator.getMsg('match').substitute({matchName: props.matchName || document.id(props.matchInput).get('name')});
+			return Form.Validator.getMsg('match').substitute({matchName: decodeURIComponent((props.matchName+'').replace(/\+/g, '%20')) || document.id(props.matchInput).get('name')});
 		},
 		test: function(element, props){
 			var eleVal = element.get('value');


### PR DESCRIPTION
Fix validate-match "matchName" not "working" if containing spaces
(See https://github.com/mootools/mootools-more/issues/1185 )