### PR TITLE
Bugfix to Form.Validator.Extras - validate-reqchk-byname

### DIFF
--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -54,23 +54,20 @@ Form.Validator.addAllThese([
 	}],
 	
 	['validate-enforce-onselect-value', {
-			errorMsg: function(element, props){
-				return Form.Validator.getMsg('selectOptMax').substitute({label: props.label});
-			},
-			test: function(element, props){
-				if( !props.value ) return true;
-				var fv = element.getParent('form').retrieve('validator');
-				if (!fv) return true;
-				(props.toEnforce || document.id(props.enforceChildrenOf).getElements('input, select, textarea')).map(function(item){
-					if (props.value == element.value){
-						fv.enforceField(item);
-					} else {
-						fv.ignoreField(item);
-						fv.resetField(item);
-					}
-				});
-				return true;
-			}
+		test: function(element, props){
+			if( !props.value ) return true;
+			var fv = element.getParent('form').retrieve('validator');
+			if (!fv) return true;
+			(props.toEnforce || document.id(props.enforceChildrenOf).getElements('input, select, textarea')).map(function(item){
+				if (props.value == element.value){
+					fv.enforceField(item);
+				} else {
+					fv.ignoreField(item);
+					fv.resetField(item);
+				}
+			});
+			return true;
+		}
 	}],
 
 	['validate-nospace', {

--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -52,6 +52,26 @@ Form.Validator.addAllThese([
 			return true;
 		}
 	}],
+	
+	['validate-enforce-onselect-value', {
+			errorMsg: function(element, props){
+				return Form.Validator.getMsg('selectOptMax').substitute({label: props.label});
+			},
+			test: function(element, props){
+				if( !props.value ) return true;
+				var fv = element.getParent('form').retrieve('validator');
+				if (!fv) return true;
+				(props.toEnforce || document.id(props.enforceChildrenOf).getElements('input, select, textarea')).map(function(item){
+					if (props.value == element.value){
+						fv.enforceField(item);
+					} else {
+						fv.ignoreField(item);
+						fv.resetField(item);
+					}
+				});
+				return true;
+			}
+	}],
 
 	['validate-nospace', {
 		errorMsg: function(){

--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -107,13 +107,14 @@ Form.Validator.addAllThese([
 		},
 		test: function(element, props){
 			var grpName = props.groupName || element.get('name');
-			var grpNameEls = $$(document.getElementsByName(grpName));
+			var grpNameEls = $$('[name=' + grpName +']');
 			var oneCheckedItem = grpNameEls.some(function(item, index){
 				return item.checked;
 			});
 			var fv = element.getParent('form').retrieve('validator');
-			if (oneCheckedItem && fv) 
+			if (oneCheckedItem && fv) {
 				grpNameEls.each(function(item, index) { fv.resetField(item); });
+			}
 			return oneCheckedItem;
 		}
 	}],

--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -107,11 +107,13 @@ Form.Validator.addAllThese([
 		},
 		test: function(element, props){
 			var grpName = props.groupName || element.get('name');
-			var oneCheckedItem = $$(document.getElementsByName(grpName)).some(function(item, index){
+			var grpNameEls = $$(document.getElementsByName(grpName));
+			var oneCheckedItem = grpNameEls.some(function(item, index){
 				return item.checked;
 			});
 			var fv = element.getParent('form').retrieve('validator');
-			if (oneCheckedItem && fv) fv.resetField(element);
+			if (oneCheckedItem && fv) 
+				grpNameEls.each(function(item, index) { fv.resetField(item); });
 			return oneCheckedItem;
 		}
 	}],


### PR DESCRIPTION
Bugfix to validate-reqchk-byname - not hiding error messages properly when one checkbox is unchecked, producing an eror underneath it, then another checkbox is checked, and the previous error doesn't go away.
example: http://jsfiddle.net/aUFe4/1/