### PR TITLE
Fix for Drag.Move + without compatibility + droppables Array

### DIFF
--- a/Source/Drag/Drag.Move.js
+++ b/Source/Drag/Drag.Move.js
@@ -44,6 +44,9 @@ Drag.Move = new Class({
 		this.parent(element, options);
 		element = this.element;
 
+	        if (typeOf(this.options.droppables) == 'array')
+        	    this.options.droppables = this.options.droppables.join(',');
+
 		this.droppables = $$(this.options.droppables);
 		this.container = document.id(this.options.container);
 


### PR DESCRIPTION
if this.options.droppables is an array, $$() or getElements not working in MooTools Core 1.4.5 without compatibility.

not working:
$$( ['.one', '.two'] )

working:
$$( ['.one', '.two'].join(',') )
