### PR TITLE
Slider.js - value always set to max on setRange

### DIFF
--- a/Source/Drag/Slider.js
+++ b/Source/Drag/Slider.js
@@ -160,7 +160,7 @@ var Slider = new Class({
 		this.steps = this.options.steps || this.full;
 		this.stepSize = Math.abs(this.range) / this.steps;
 		this.stepWidth = this.stepSize * this.full / Math.abs(this.range);
-		if (range) this.set(Array.pick([pos, this.step]).floor(this.max).max(this.min));
+		if (range) this.set(Array.pick([pos, this.step]).limit(this.min,this.max));
 		return this;
 	},
 


### PR DESCRIPTION
When changing the range of a slider it would always change the value of the slider to the max of the range.
