### PR TITLE
Improved Sortables doc, making it clear that serialize() returns ids

### DIFF
--- a/Docs/Drag/Sortables.md
+++ b/Docs/Drag/Sortables.md
@@ -251,7 +251,7 @@ Sortables Method: serialize {#Sortables:serialize}
 --------------------------------------------------
 
 Function to get the order of the elements in the lists of this sortables instance.
-For each list, an array containing the *id*s of all the elements (in the current order) will be returned.
+For each list, an array containing the *id* of all the elements (in the current order) will be returned.
 If more than one list is being used, all lists will be serialized and returned in an array.
 
 ### Syntax:


### PR DESCRIPTION
I noticed it's not said that `Sortable.serialize()` returns an array containing the _id_ property of sorted elements, not the elements themselves. It's important, because we should set _id_ attributes to make it work (if custom _modifier_ function is not given).

I took the opportunity to beautify other parts of that doc file too.
