### PR TITLE
Allowing the refresh of droppables on start dragging.

### DIFF
--- a/Source/Drag/Drag.Move.js
+++ b/Source/Drag/Drag.Move.js
@@ -37,7 +37,8 @@ Drag.Move = new Class({
 		container: false,
 		precalculate: false,
 		includeMargins: true,
-		checkDroppables: true
+		checkDroppables: true,
+		refreshDroppables: false
 	},
 
 	initialize: function(element, options){
@@ -67,6 +68,8 @@ Drag.Move = new Class({
 	},
 
 	start: function(event){
+		if (this.options.refreshDroppables) this.droppables = $$(this.options.droppables);
+		
 		if (this.container) this.options.limit = this.calculateLimit();
 
 		if (this.options.precalculate){


### PR DESCRIPTION
If refreshDroppables is set to true, when starting the drag, it will refresh the droppables list so it can take the newest DOM objects in consideration.

cf. http://jsfiddle.net/wordsbybird/TAVfk/
