### PR TITLE
Added the 'move' event to the Slider class.

### DIFF
--- a/Docs/Drag/Slider.md
+++ b/Docs/Drag/Slider.md
@@ -79,6 +79,15 @@ Fires when the user scrolls or when the container element is clicked. This Event
 - By default Slider uses the 'tick' event to set the style of the knob to a new position.
 
 
+#### move
+
+Fires when the knob is moved, whether by dragging or by changing the value of the slider.
+
+##### Signature
+
+	onMove()
+
+
 ### Returns
 
 * (*object*) A new Slider instance.

--- a/Source/Drag/Slider.js
+++ b/Source/Drag/Slider.js
@@ -31,6 +31,7 @@ var Slider = new Class({
 
 	options: {/*
 		onTick: function(intPosition){},
+		OnMove: function(){},
 		onChange: function(intStep){},
 		onComplete: function(strStep){},*/
 		onTick: function(position){
@@ -150,6 +151,7 @@ var Slider = new Class({
 		this.step = Math.round(step);
 		return this.checkStep()
 			.fireEvent('tick', this.toPosition(this.step))
+			.fireEvent('move')
 			.end();
 	},
 
@@ -176,6 +178,7 @@ var Slider = new Class({
 
 		this.checkStep()
 			.fireEvent('tick', position)
+			.fireEvent('move')
 			.end();
 	},
 
@@ -193,6 +196,7 @@ var Slider = new Class({
 
 		this.step = Math.round(this.min + dir * this.toStep(position));
 		this.checkStep();
+		this.fireEvent('move');
 	},
 
 	checkStep: function(){


### PR DESCRIPTION
Third parties can listen to the proposed `move` event to be notified when the knob moves, whether when the knob is dragged or when the value of the slider is changed. I created a demo on jsFiddle:

http://fiddle.jshell.net/olvlvl/JHLqT/

Also some events are triggered during initialize :(
