### PR TITLE
Uri setdata respect part

### DIFF
--- a/Source/Types/URI.js
+++ b/Source/Types/URI.js
@@ -131,7 +131,7 @@ var URI = this.URI = new Class({
 	},
 
 	setData: function(values, merge, part){
-                part = part || 'query';
+		part = part || 'query';
 		if (typeof values == 'string'){
 			var data = this.getData(undefined, part);
 			data[arguments[0]] = arguments[1];


### PR DESCRIPTION
Hi,

I was trying to use setData to set part of a fragment on a URI and it didn't work as expected. Only the new data was present. I seems that setData always got the current data from the default place (query string) and my query string was empty.

So here's a patch.
