### PR TITLE
fixes validator parameters allowing spaces in them

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -69,7 +69,9 @@ var InputValidator = this.InputValidator = new Class({
 Element.Properties.validators = {
 
 	get: function(){
-		return (this.get('data-validators') || this.className).clean().split(' ');
+		return (this.get('data-validators') || this.className).clean().replace(/'(\\.|[^'])*'|"(\\.|[^"])*"/g, function(match){
+			return match.replace(' ', '\\x20');
+		}).split(' ');
 	}
 
 };

--- a/Tests/Specs/1.3/Forms/Form.Validator.js
+++ b/Tests/Specs/1.3/Forms/Form.Validator.js
@@ -20,6 +20,11 @@ describe('Form.Validator', function(){
 			expect(element.get('validatorProps')).toEqual({minLength: 10});
 		});
 
+		it('should get the properties from string with spaces', function(){
+			var input = new Element('input', {'data-validators': 'label:\'primary category\''});
+			expect(input.get('validatorProps')).toEqual({label: "primary category"});
+		});
+
 		it('should get the validator properties from a JSON string in the validatorProps attribute', function(){
 			var element = new Element('input').setProperty('validatorProps', '{minLength: 10, maxLength:20}');
 			expect(element.get('validatorProps')).toEqual({minLength: 10, maxLength: 20});


### PR DESCRIPTION
The pull request allows validator parameters specified in data-validators attribute (or legacy class) after validator name  to have spaces in their values, e.g.
```html
<input type="radio" name="primary_category" data-validators="validate-reqchk-byname label:'primary category'" />
...
```
