### PR TITLE
Adds onError <script> event support to Request.JSONP

### DIFF
--- a/Source/Request/Request.JSONP.js
+++ b/Source/Request/Request.JSONP.js
@@ -41,7 +41,7 @@ Request.JSONP = new Class({
 			}
 		},
 		onError: function(src){
-			if (this.options.log && window.console && console.warn){
+			if (src.length > 2083 && this.options.log && window.console && console.warn){
 				console.warn('JSONP '+ src +' will fail in Internet Explorer, which enforces a 2083 bytes length limit on URIs');
 			}
 		},
@@ -98,7 +98,12 @@ Request.JSONP = new Class({
 		if (!this.script) this.script = new Element('script', {
 			type: 'text/javascript',
 			async: true,
-			src: src
+			src: src,
+			events: {
+				error: function() {
+					this.fireEvent('error', [src]);
+				}.bind(this)
+			}
 		});
 		return this.script;
 	},

--- a/Tests/Interactive/Request/Request.JSONP_(onerror).html
+++ b/Tests/Interactive/Request/Request.JSONP_(onerror).html
@@ -1,0 +1,23 @@
+<a id="fetch">Make a jsonp request to a non-existent resource.</a>
+<hr/>
+<div id="loading"></div>
+<div id="response"></div>
+
+<script src="/depender/build?require=More/Request.JSONP,Core/Element.Event"></script>
+<script>
+$('fetch').addEvent('click', function(){
+	new Request.JSONP({
+		log: true,
+		url: '/no/such/file',
+		onComplete: function(data){ },
+		onRequest: function(){
+			$('loading').set('text', 'Loading...');
+		},
+		onError: function() {
+			$('response').set('text', 'success - error event was triggered');
+			$('loading').set('text', '');
+		}
+	}).send();
+});
+
+</script>

--- a/Tests/Interactive/Request/Request.JSONP_(onerror).yml
+++ b/Tests/Interactive/Request/Request.JSONP_(onerror).yml
@@ -1,0 +1,2 @@
+js-references:
+  - "More/Request.JSONP"


### PR DESCRIPTION
In HTML5 an onerror event was added to the script tag. This can be used by JSONP to detect loading errors. This pull request links the `<script>` onerror event to the `Request.JSONP` one.

In browsers that do not support HTML5 the event will simply not be triggered, and the behaviour will be the same as previously.
