### PR TITLE
Back button now jumps back to previous scroll position.

### DIFF
--- a/Source/Fx/Fx.SmoothScroll.js
+++ b/Source/Fx/Fx.SmoothScroll.js
@@ -39,15 +39,10 @@ provides: [Fx.SmoothScroll]
 			links = $$(this.options.links || this.doc.links);
 
 		links.each(function(link){
-			if (link.href.indexOf(location) != 0) return;
+			if (link.href.indexOf(location) !== 0) return;
 			var anchor = link.href.substr(location.length);
 			if (anchor) this.useLink(link, anchor);
 		}, this);
-
-		this.addEvent('complete', function(){
-			win.location.hash = this.anchor;
-			this.element.scrollTo(this.to[0], this.to[1]);
-		}, true);
 	},
 
 	useLink: function(link, anchor){
@@ -57,6 +52,14 @@ provides: [Fx.SmoothScroll]
 			if (!el) return;
 
 			event.preventDefault();
+
+			var current = {
+				x: this.doc.scrollLeft,
+				y: this.doc.scrollTop
+			};
+			window.location.hash = anchor;
+			this.set(current.x, current.y);
+
 			this.toElement(el, this.options.axes).chain(function(){
 				this.fireEvent('scrolledTo', [link, el]);
 			}.bind(this));

--- a/Source/Fx/Fx.SmoothScroll.js
+++ b/Source/Fx/Fx.SmoothScroll.js
@@ -53,10 +53,7 @@ provides: [Fx.SmoothScroll]
 
 			event.preventDefault();
 
-			var current = {
-				x: this.doc.scrollLeft,
-				y: this.doc.scrollTop
-			};
+			var current = document.documentElement.getScroll();
 			window.location.hash = anchor;
 			this.set(current.x, current.y);
 


### PR DESCRIPTION
Originally, pressing the back button would do nothing because the hash was being set after scrolling. This meant that the browser's stored position was the one that had just been scrolled to.

This patch sets the hash before scrolling, thus storing the actual previous position. This causes the browser to jump to the anchor, so the script jumps back to the previous position and then scrolls to the new position.
