### PR TITLE
New more module : Class.Static

### DIFF
--- a/Source/Class/Class.Static.js
+++ b/Source/Class/Class.Static.js
@@ -1,0 +1,36 @@
+/*
+---
+
+script: Class.Static.js
+
+name: Class.Static
+
+description: Allow classes to define "static" methods from declaration, (as Object.extend afterwards).
+
+license: MIT-style license.
+
+authors:
+  - Francois Leurent
+
+requires:
+  - Core/Class
+  - /MooTools.More
+
+
+provides: [Class.Static]
+
+...
+*/
+
+
+Function.prototype.static = function(){
+  this.$static = true;
+  return this;
+}
+
+var legacy = Class.prototype.implement;
+Class.implement('implement', function(k,v){
+  if(v.$static) this[k] = v;
+  else legacy.apply(this, [k, v]);
+}.overloadSetter());
+

--- a/Tests/Interactive/Class/Class.Static_(tween).html
+++ b/Tests/Interactive/Class/Class.Static_(tween).html
@@ -1,0 +1,18 @@
+<p>
+	The element below should say "hello world"
+</p>
+<div id="foo" style="width: 200px; border: 1px solid black; height: 200px; overflow:hidden;background:silver;">
+</div>
+<script src="/depender/build?require=More/Class.Static"></script>
+<script>
+  var n = new Class({
+    bar:function(){
+      $('foo').set('text', 'hello world');
+    }.static(),
+  });
+
+  n.bar();
+
+</script>
+
+

--- a/Tests/Interactive/Class/Class.Static_(tween).yml
+++ b/Tests/Interactive/Class/Class.Static_(tween).yml
@@ -1,0 +1,2 @@
+js-references:
+  - "More/Class.Static"

--- a/package.yml
+++ b/package.yml
@@ -19,6 +19,7 @@ sources:
   - "Source/Class/Events.Pseudos.js"
   - "Source/Class/Class.Refactor.js"
   - "Source/Class/Class.Binds.js"
+  - "Source/Class/Class.Static.js"
   - "Source/Class/Class.Occlude.js"
   - "Source/Class/Chain.Wait.js"
   - "Source/Types/Array.Extras.js"


### PR DESCRIPTION
Allow "static" (non prototype method) declaration in new Class({}) syntax, remove the common need to have a "second" pass of class declaration with myClass.extend({}); ...