### PR TITLE
Add .hasOwnProperty checks, fixes #1223

### DIFF
--- a/Source/Interface/HtmlTable.js
+++ b/Source/Interface/HtmlTable.js
@@ -110,10 +110,10 @@ var HtmlTable = new Class({
 
 		row.each(function(data, index){
 			var td = tds[index] || new Element(tag || 'td').inject(tr),
-				content = (data ? data.content : '') || data,
+				content = ((data && data.hasOwnProperty('content')) ? data.content : '') || data,
 				type = typeOf(content);
 
-			if (data && data.properties) td.set(data.properties);
+			if (data && data.hasOwnProperty('properties')) td.set(data.properties);
 			if (/(element(s?)|array|collection)/.test(type)) td.empty().adopt(content);
 			else td.set('html', content);
 


### PR DESCRIPTION
As detailed on #1223, Firefox 27 started exposing a new HTMLPropertiesCollection interface on HTMLElement.
Since all elements on the DOM inherit from HTMLElement we can safely safeguard our code against confusing a plain object with an element by checking if `.properties` has been intentionally defined or it's inherited from the parent prototype.

I added the same check on `.content` just to remain on the safe side. We never know if/when this interface could also be added on HTMLElement (or poor code modifying `Object`'s prototype)
