### PR TITLE
Fix getComputedSize() in Element.Measure.js

### DIFF
--- a/Source/Element/Element.Measure.js
+++ b/Source/Element/Element.Measure.js
@@ -141,12 +141,8 @@ Element.implement({
 		}
 
 		getStylesList(options.styles, options.planes).each(function(style){
-			try {
-				var value = this.getStyle(style).toInt();
-				styles[style] = isNaN(value) ? 0 : value;
-			} catch (err) {
-				styles[style] = 0;
-			}
+			var value = parseInt(this.getStyle(style));
+			styles[style] = isNaN(value) ? 0 : value;
 		}, this);
 
 		Object.each(options.planes, function(edges, plane){
@@ -156,11 +152,8 @@ Element.implement({
 
 			if (style == 'auto' && !dimensions) dimensions = this.getDimensions();
 
-			try {
-				style = styles[plane] = (style == 'auto') ? dimensions[plane] : style.toInt();
-			} catch (err) {
-				style = styles[plane] = 0;
-			}
+			var value = (style == 'auto') ? dimensions[plane] : parseInt(style);
+			style = styles[style] = isNaN(value) ? 0 : value;
 			size['total' + capitalized] = style;
 
 			edges.each(function(edge){


### PR DESCRIPTION
If the style is some string and `this.getStyle(style).toInt()` returns `NaN` then the results value of `totalWidth` and `totalHeight` also will be `NaN`. I recommend to set the value in this situations to `0`.

I had this problem in Opera and IE. For example, `border-top-width` was automatic set by browser to `medium`. The conversion of this value into integer returns `NaN`. Therefore, after next calculation, `totalWidth` and `totalHeght` will be `NaN`.

Similar problem in the case when `getStyle(style)` returns `null` and `null.toInt()` of course generates an error. For this case it is also better to set the result to `0` instead to receive some unexpected values.
