### PR TITLE
Fixed floatLax in HtmlTable.Sort

### DIFF
--- a/Source/Interface/HtmlTable.Sort.js
+++ b/Source/Interface/HtmlTable.Sort.js
@@ -318,7 +318,7 @@ HtmlTable.Parsers = {
 	'floatLax': {
 		match: /^[^\d]+[\d]+\.[\d]+$/,
 		convert: function(){
-			return this.get('text').replace(/[^-?^\d.]/, '').stripTags();
+			return this.get('text').replace(/[^-?^\d.]/, '').stripTags().toFloat();
 		},
 		number: true
 	},


### PR DESCRIPTION
Major bug here, the text was never getting converted into a float and
therefore could never get properly sorted.
