### PR TITLE
Cc remove sniff html table sort

### DIFF
--- a/Source/Interface/HtmlTable.Sort.js
+++ b/Source/Interface/HtmlTable.Sort.js
@@ -29,10 +29,10 @@ provides: [HtmlTable.Sort]
 (function(){
 
 var readOnlyNess = document.createElement('table');
-try{
+try {
 	readOnlyNess.innerHTML = '<tr><td></td></tr>';
 	readOnlyNess = readOnlyNess.childNodes.length === 0;
-}catch(e){
+} catch (e){
 	readOnlyNess = true;
 }
 


### PR DESCRIPTION
replaced:

``` javascript
if (!Browser.ie){
   rel = this.body.getParent();
   this.body.dispose();
}
```

with:

``` javascript
    var readOnlyNess = document.createElement('table');
    try{
        readOnlyNess.innerHTML = '<tr><td></td></tr>';
        readOnlyNess = readOnlyNess.childNodes.length === 0;
    }catch(e){
        readOnlyNess = true;
    }
if (!readOnlyNess){
   rel = this.body.getParent();
   this.body.dispose();
}
```

Apparently we don't want to run that code in IE, I think it's because it creates some problem since IE's `TABLE` element has a different table object model, 
in order to know if we are working on this _special_ object model we can use another peculiarity of the IE Table Object Model which is the fact that for `TABLE` and `TR` elements the `innerHTML` property is readonly.

More Info about IE Table Object Model here: http://msdn.microsoft.com/en-us/library/ie/ms532998(v=vs.85).aspx
