### PR TITLE
Removing sniffing in Drag, more info in the PR

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -66,10 +66,10 @@ var Drag = new Class({
 		this.mouse = {'now': {}, 'pos': {}};
 		this.value = {'start': {}, 'now': {}};
 
-		this.selection = (Browser.ie) ? 'selectstart' : 'mousedown';
+		this.selection = 'selectstart' in document ? 'selectstart' : 'mousedown';
 
 
-		if (Browser.ie && !Drag.ondragstartFixed){
+		if ('ondragstart' in document && !('FileReader' in window) && !Drag.ondragstartFixed){
 			document.ondragstart = Function.from(false);
 			Drag.ondragstartFixed = true;
 		}


### PR DESCRIPTION
Removed:

``` javascript
this.selection = (Browser.ie) ? 'selectstart' : 'mousedown';
```

Replaced with:

``` javascript
this.selection = 'selectstart' in document ? 'selectstart' : 'mousedown';
```

if the document supports selectstart we will default on that (I think only IE supports that anyway).

Removed:

``` javascript
if (Browser.ie && !Drag.ondragstartFixed)
```

Replaced with:

``` javascript
if ('ondragstart' in document && !('FileReader' in window) && !Drag.ondragstartFixed)
```

`ondragstart` is now a standard, so the check for the event `ondragstart` is not enough, we have to be a bit more careful here and look if `FileReader` is also present.

Why `FileReader`? Because we should test for `dataTransfer`, but apparently is [_undetectable_](https://github.com/Modernizr/Modernizr/wiki/Undetectables) so we need to check for something else associated with it, and here they suggest to rely on FileReader instead. https://github.com/Modernizr/Modernizr/issues/57#issuecomment-4187079
