### PR TITLE
Removing sniffing in Element.Event.Pseudos.Keys, more info in the PR

### DIFF
--- a/Source/Element/Element.Event.Pseudos.Keys.js
+++ b/Source/Element/Element.Event.Pseudos.Keys.js
@@ -77,7 +77,9 @@ DOMEvent.defineKeys({
 	'220': '\\',
 	'221': ']',
 	'222': "'",
-	'107': '+'
-}).defineKey(Browser.firefox ? 109 : 189, '-');
+	'107': '+',
+	'109': '-', // subtract
+	'189': '-'  // dash
+})
 
 })();


### PR DESCRIPTION
Apparently the assumption that in firefox the keycode is 109 and 189 for the '-' key is wrong,
in fact both are correct, in particular the '109' is the code that comes from the subtract button on the keypad while '189'  is the dash one. 
Both fires the same keychar (45) so the proper solution is adding both and just get rid of the sniff.

You can find the same logic in Syn:
https://github.com/bitovi/syn/blob/master/src/key.js#L246
https://github.com/bitovi/syn/blob/master/src/key.js#L254
