### PR TITLE
Removing sniffing in Fx.Scroll, more info in the PR

### DIFF
--- a/Source/Fx/Fx.Scroll.js
+++ b/Source/Fx/Fx.Scroll.js
@@ -54,7 +54,6 @@ Fx.Scroll = new Class({
 
 	set: function(){
 		var now = Array.flatten(arguments);
-		if (Browser.firefox) now = [Math.round(now[0]), Math.round(now[1])]; // not needed anymore in newer firefox versions
 		this.element.scrollTo(now[0], now[1]);
 		return this;
 	},


### PR DESCRIPTION
In 2010 @arian said that that line wasn't needed anymore, I can't understand how after 4 year is still there, @arian is right 100% of the times, and we can't round anymore since in 2014 subpixel calculation is a must.
