### PR TITLE
Removing sniffing in Fx.Reveal, more info in the PR

### DIFF
--- a/Source/Fx/Fx.Reveal.js
+++ b/Source/Fx/Fx.Reveal.js
@@ -50,13 +50,13 @@ Fx.Reveal = new Class({
 		widthOverride: null,*/
 		link: 'cancel',
 		styles: ['padding', 'border', 'margin'],
-		transitionOpacity: !Browser.ie6,
+		transitionOpacity: 'opacity' in document.documentElement,
 		mode: 'vertical',
 		display: function(){
 			return this.element.get('tag') != 'tr' ? 'block' : 'table-row';
 		},
 		opacity: 1,
-		hideInputs: Browser.ie ? 'select, input, textarea, object, embed' : null
+		hideInputs: !('opacity' in document.documentElement) ? 'select, input, textarea, object, embed' : null
 	},
 
 	dissolve: function(){


### PR DESCRIPTION
Removed:

``` javascript
!Browser.ie6
```

Substituted with:

``` javascript
'opacity' in document.documentElement
```

I realise that this is not the same since `opacity` will not be available until ie9, but even so, later hideinputs will consider all ie version, I believe the correct behaviour will be this one, fine to change it if you provide a better solution.
