### PR TITLE
Removing sniffing in Swiff, more info in the PR

### DIFF
--- a/Source/Utilities/Swiff.js
+++ b/Source/Utilities/Swiff.js
@@ -68,7 +68,7 @@ var Swiff = this.Swiff = new Class({
 		}
 
 		params.flashVars = Object.toQueryString(vars);
-		if (Browser.ie){
+		if ('ActiveXObject' in window){
 			properties.classid = 'clsid:D27CDB6E-AE6D-11cf-96B8-444553540000';
 			params.movie = path;
 		} else {


### PR DESCRIPTION
since `classid` is used only for the `ActiveX` version of Flash, I changed the instance of 

``` javascript
Browser.ie
```

with

``` javascript
'ActiveXObject' in window
```
