### PR TITLE
use Object.prototype to avoid old IE's

### DIFF
--- a/Source/Interface/HtmlTable.js
+++ b/Source/Interface/HtmlTable.js
@@ -110,10 +110,10 @@ var HtmlTable = new Class({
 
 		row.each(function(data, index){
 			var td = tds[index] || new Element(tag || 'td').inject(tr),
-				content = ((data && data.hasOwnProperty('content')) ? data.content : '') || data,
+				content = ((data && Object.prototype.hasOwnProperty.call(data, 'content')) ? data.content : '') || data,
 				type = typeOf(content);
 
-			if (data && data.hasOwnProperty('properties')) td.set(data.properties);
+			if (data && Object.prototype.hasOwnProperty.call(data, 'properties')) td.set(data.properties);
 			if (/(element(s?)|array|collection)/.test(type)) td.empty().adopt(content);
 			else td.set('html', content);
 


### PR DESCRIPTION
"IE6-8 don't implement hasOwnProperty on hosts object (like window)"

Related info [here](https://github.com/mootools/mootools-more/commit/0450a3d04bf5b769d38cb976ac7c3f9bf78cf4a8#commitcomment-5971036)
