### PR TITLE
nocompat fix for .type

### DIFF
--- a/Specs/Types/Hash.js
+++ b/Specs/Types/Hash.js
@@ -8,9 +8,9 @@ provides: [Hash.Tests]
 
 (function(){
 
-function isNumber(num){ return typeof num == 'number'; };
-function isArray(arr){ return typeOf(arr) == 'array'; };
-function $defined(obj) { return obj != null };
+function isNumber(num){ return typeof num == 'number'; }
+function isArray(arr){ return typeOf(arr) == 'array'; }
+function $defined(obj){ return obj != null; }
 
 var hash2 = new Hash({ a: 'string', b: 233, c: {} });
 


### PR DESCRIPTION
Replace specs methods that are not available in nocompat like
Number.type, Hash.type and Array.type
