### PR TITLE
URI fix

### DIFF
--- a/Specs/Types/URI.Relative.js
+++ b/Specs/Types/URI.Relative.js
@@ -38,12 +38,12 @@ var uri;
 		beforeEach(function(){
 			uri = new URI('http://www.calyptus.eu/mydirectory/mydirectory2/myfile.html');
 		});
-		it('new URI(\'../otherfolder\').toRelative() should return a folder up from the current location', function(){
-			expect(new URI('../otherfolder').toRelative()).toEqual('../otherfolder');
+		it('new URI(\'../base/otherfolder\').toRelative() should return a folder up from the current location', function(){
+			expect(new URI('../base/otherfolder').toRelative()).toEqual('../base/otherfolder');
 		});
 
-		it('new URI(\'../otherfolder\').toRelative(currentLocation) should return a folder up from the current location', function(){
-			expect(new URI('../otherfolder').toRelative(window.location)).toEqual('../otherfolder');
+		it('new URI(\'../base/otherfolder\').toRelative(currentLocation) should return a folder up from the current location', function(){
+			expect(new URI('../base/otherfolder').toRelative(window.location)).toEqual('../base/otherfolder');
 		});
 
 		it('URI.toRelative(string)', function(){
@@ -100,14 +100,6 @@ var uri;
 
 		it('URI.toRelative(string) to same path', function(){
 			expect(new URI('http://www.calyptus.eu').toRelative('http://www.calyptus.eu')).toEqual('./');
-		});
-
-		it('new URI(\'../otherfolder\').toRelative() should return the same as input', function(){
-			expect(new URI('../otherfolder').toRelative(window.location)).toEqual('../otherfolder');
-		});
-
-		it('new URI(\'../otherfolder\').toRelative(window.location) should return the same as input', function(){
-			expect(new URI('../otherfolder').toRelative(window.location)).toEqual('../otherfolder');
 		});
 
 	});

--- a/Specs/Types/URI.js
+++ b/Specs/Types/URI.js
@@ -70,7 +70,7 @@ provides: [URI.Tests]
 
 	});
 
-	describe('URI methods', function(){
+	describe('URI methods without query in url', function(){
 
 		beforeEach(function(){
 			uri = new URI('http://www.calyptus.eu/mydirectory/mydirectory2/myfile.html');
@@ -86,7 +86,14 @@ provides: [URI.Tests]
 			uri.setData({ keyName: 'my value' });
 			expect(uri.get('query')).toEqual('keyName=my%20value');
 		});
+	});
 
+	describe('URI methods with query in url', function(){
+
+		beforeEach(function(){
+			uri = new URI('http://www.calyptus.eu/mydirectory/mydirectory2/myfile.html?keyName=my%20value');
+		});
+        
 		it('URI.getData() should return an object with the value set above', function(){
 			expect(uri.getData().keyName).toEqual('my value');
 		});


### PR DESCRIPTION
URI - separate tests because `beforeEach` resets the variable and tests
were depending on each other instead of being separated

URI.Relative:
- removed a duplicated test
- refactor url to match Karma server's "/base/" added to path
