### PR TITLE
fixes #1199

### DIFF
--- a/Source/Element/Element.Pin.js
+++ b/Source/Element/Element.Pin.js
@@ -50,11 +50,13 @@ provides: [Element.Pin]
 				scrollFixer;
 
 			if (enable !== false){
-				pinnedPosition = this.getPosition(supportsPositionFixed ? document.body : this.getOffsetParent());
-				if (!this.retrieve('pin:_pinned')){
+				pinnedPosition = this.getPosition();
+				if (!this.retrieve('pin:_pinned')) {
 					var currentPosition = {
 						top: pinnedPosition.y - scroll.y,
-						left: pinnedPosition.x - scroll.x
+						left: pinnedPosition.x - scroll.x,
+						margin: '0px',
+						padding: '0px'
 					};
 
 					if (supportsPositionFixed && !forceScroll){
@@ -94,7 +96,7 @@ provides: [Element.Pin]
 				parent = this.getParent();
 				var offsetParent = (parent.getComputedStyle('position') != 'static' ? parent : parent.getOffsetParent());
 
-				pinnedPosition = this.getPosition(offsetParent);
+				pinnedPosition = this.getPosition();
 
 				this.store('pin:_pinned', false);
 				scrollFixer = this.retrieve('pin:_scrollFixer');


### PR DESCRIPTION
Element.pin is buggy: 
Buggy example: http://jsfiddle.net/2n4Ad/
Fixed example: http://jsfiddle.net/2n4Ad/1

This fixes the documented behaviour.  Tested in IE6, 7, 8 , 11; FF &&
Chrome

There are more parameters/methods in Element.pin. They are not
documented. According to docs, `.pin()` takes just 1 parameter...

fixes #1199 
