### PR TITLE
Correct documentation for `.formUpdate`

### DIFF
--- a/Docs/Forms/Form.Request.md
+++ b/Docs/Forms/Form.Request.md
@@ -49,7 +49,7 @@ Changes the target that the instance will update with the Request response.
 
 ### Syntax
 
-	myFormRequest.setTarget(newTarget);
+	myformUpdate.setTarget(newTarget);
 
 ### Arguments
 
@@ -66,7 +66,7 @@ Sends the form.
 
 ### Syntax
 
-	myFormRequest.send();
+	myformUpdate.send();
 
 ### Returns
 
@@ -79,7 +79,7 @@ Detaches the Form.Request from the form (disabling the ajax).
 
 ### Syntax
 
-	myFormRequest.disable();
+	myformUpdate.disable();
 
 ### Returns
 
@@ -92,7 +92,7 @@ Attaches the Form.Request to the form (enabling the ajax). Note that this is don
 
 ### Syntax
 
-	myFormRequest.enable();
+	myformUpdate.enable();
 
 ### Returns
 
@@ -103,14 +103,14 @@ Type: Element {#Element}
 
 Extends the [Element][] Type with a reference to its [Form.Request][] instance and a method to create one.
 
-Element Method: formRequest {#Element:formRequest}
+Element Method: formUpdate {#Element:formUpdate}
 -------------------------------------
 
 Creates a new instance of [Form.Request][] and calls its *send* method.
 
 ### Syntax
 
-	$(element).formRequest(update, options);
+	$(element).formUpdate(update, options);
 
 ### Arguments
 
@@ -123,7 +123,7 @@ Creates a new instance of [Form.Request][] and calls its *send* method.
 
 ### Example
 
-	$(element).formRequest($('myDiv'), { requestOptions: {useSpinner: false } });
+	$(element).formUpdate($('myDiv'), { requestOptions: {useSpinner: false } });
 
 Element property: form.request {#Element:form.request}
 ------------------------------------------------


### PR DESCRIPTION
Documentation refers to a method `element.formRequest`. 
Such method [does not exist (jsfiddle)](http://jsfiddle.net/CHEuL/).

The method correct name is **[.formUpdate](https://github.com/mootools/mootools-more/blob/master/Source/Forms/Form.Request.js#L191)**

``` js
console.log($('myForm').formUpdate);  // function (update, options){ ...
console.log($('myForm').formRequest); // undefined
```

fixes #254
fixes #1056
