### PR TITLE
fixes #230, this.previous returns wrong index

### DIFF
--- a/Source/Fx/Fx.Accordion.js
+++ b/Source/Fx/Fx.Accordion.js
@@ -164,18 +164,19 @@ Fx.Accordion = new Class({
 
 		if (useFx == null) useFx = true;
 		if (typeOf(index) == 'element') index = elements.indexOf(index);
-		if (index == this.previous && !options.alwaysHide) return this;
+		if (index == this.current && !options.alwaysHide) return this;
 
 		if (options.resetHeight){
-			var prev = elements[this.previous];
+			var prev = elements[this.current];
 			if (prev && !this.selfHidden){
 				for (var fx in effects) prev.setStyle(fx, prev[effects[fx]]);
 			}
 		}
 
-		if ((this.timer && options.link == 'chain') || (index === this.previous && !options.alwaysHide)) return this;
+		if ((this.timer && options.link == 'chain') || (index === this.current && !options.alwaysHide)) return this;
 
-		this.previous = index;
+		if (this.current != null) this.previous = this.current;
+		this.current = index;
 		this.selfHidden = false;
 
 		elements.each(function(el, i){


### PR DESCRIPTION
Accordion's `this.previous` is returning wrong values.
Example (wrong behaviour): http://jsfiddle.net/9TnkF/

`this.previous` is returning the current open, instead of last opened.

New version (correct behaviour): http://jsfiddle.net/BgGCN/

fixes #230
