### PR TITLE
Fix number format docs

### DIFF
--- a/Docs/Types/Number.Format.md
+++ b/Docs/Types/Number.Format.md
@@ -33,8 +33,8 @@ Formats a number into a formatted string for display to user. It respects locali
 ### Examples
 
 	(123123123.176).format({
-		decimal: ".",
-		group: ",",
+		decimal: ",",
+		group: ".",
 		decimals: 2,
 		prefix: "&amp;#165;",
 		suffix: " (YEN)"


### PR DESCRIPTION
Docs example has switched `.` and `,` as pointed out in #1071.

If I would run that example I would get:

```
"&amp;#165;123,123,123.18 (YEN)"
```

And in the example it states 

```
// returns "&#165;123.123.123,18 (YEN)"
```

fixes #1071
