### PR TITLE
Make Array.sum() ignore undefined values

### DIFF
--- a/Docs/Types/Array.Extras.md
+++ b/Docs/Types/Array.Extras.md
@@ -87,7 +87,7 @@ Calling this method alters the array; it doesn't just return a new array with th
 Array Method: sum {#Array:sum}
 -------------------------------------
 
-Sums up all values in an array.
+Sums up all values in an array, including decimal numbers in *string* format.
 
 ### Syntax
 
@@ -100,7 +100,11 @@ Sums up all values in an array.
 
 ### Returns
 
-* (*number*) a number containing the sum of all values in the given array
+* (*number*) a number containing the sum of all values in the given array.
+
+### Note
+
+This method is for numbers and will return NaN if a *non-number* is present in the array.
 
 Array Method: unique {#Array:unique}
 -------------------------------------

--- a/Source/Types/Array.Extras.js
+++ b/Source/Types/Array.Extras.js
@@ -41,7 +41,9 @@ Array.implement({
 	sum: function(){
 		var result = 0, l = this.length;
 		if (l){
-			while (l--) result += this[l];
+			while (l--){
+				if (this[l] != null) result += parseFloat(this[l]);
+			}
 		}
 		return result;
 	},

--- a/Specs/Types/Array.Extras.js
+++ b/Specs/Types/Array.Extras.js
@@ -49,12 +49,47 @@ describe('Array.shuffle', function(){
 
 describe('Array.sum', function(){
 
-	it('should some up all number values', function(){
-		expect([1, 2, 3, 4, 5, 6].sum()).toEqual(21);
+	it("should return 0 for an empty array", function(){
+		expect([].sum()).toEqual(0);
 	});
 
-	it('should start concatenation if any item is not a number', function(){
-		expect([1, 2, 'a', 3].sum()).toEqual('3a21');
+	it("should sum an array with one item", function(){
+		expect([3].sum()).toEqual(3);
+	});
+
+	it("should sum an array of integers", function(){
+		expect([1, 2, 3].sum()).toEqual(6);
+	});
+
+	it("should sum an array of floats", function(){
+		expect([1.5, 2.5, 3.5].sum()).toEqual(7.5);
+	});
+
+	it("should handle numeric strings in arrays correctly", function(){
+		expect([1, "2.5", 3].sum()).toEqual(6.5);
+		expect([1, "2", 3].sum()).toEqual(6);
+	});
+
+	it("should skip null and undefined items", function(){
+		expect([1, 2, null, 4].sum()).toEqual(7);
+		expect([1, 2, undefined, 4].sum()).toEqual(7);
+	});
+
+	it("should work with a sparse array", function(){
+		var array = [1, 2];
+		array[5] = 6;
+		expect(array.sum()).toEqual(9);
+	});
+
+	it("should handle Infinity correctly", function(){
+		expect([1, 2, Infinity, 5].sum()).toEqual(Infinity);
+		expect([1, 2, -Infinity, 5].sum()).toEqual(-Infinity);
+		expect([1, 2, Infinity, 5, -Infinity].sum()).toBeNaN();
+	});
+
+	it("should return NaN when not all items are numeric", function(){
+		expect([1, 2, "", 5].sum()).toBeNaN();
+		expect([1, 2, "foo", 5].sum()).toBeNaN();
 	});
 
 });


### PR DESCRIPTION
Array.sum returns `NaN` if a array item is undefined.

```
[10, 20, undefined, 30].sum(); // "NaN"
```

This PR makes:
-  `Array.sum()` ignore `undefined` values
- more explicit in the docs that the method will return NaN if a
  _non-number_ is present in the array
- adds extra specs
##### PS: - All this is @timwienk 's credit & work!

fixes  #1114
