### PR TITLE
Restore behaviour after BC change in JSON.decode

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -101,7 +101,7 @@ Element.Properties.validatorProps = {
 					var split = cls.split(':');
 					if (split[1]){
 						try {
-							props[split[0]] = JSON.decode(split[1]);
+							props[split[0]] = JSON.decode(split[1], false);
 						} catch(e){}
 					}
 				});

--- a/Specs/Forms/Form.Validator.js
+++ b/Specs/Forms/Form.Validator.js
@@ -23,6 +23,32 @@ describe('Form.Validator', function(){
 			var element = new Element('input').setProperty('validatorProps', '{minLength: 10, maxLength:20}');
 			expect(element.get('validatorProps')).toEqual({minLength: 10, maxLength: 20});
 		});
+        
+		it('should get the properties in the class attribute from a new added Validator', function (){
+
+			var prop;
+			Form.Validator.add('validate-string-fail', {
+				errorMsg: function (element, props){
+					return Form.Validator.getMsg('required');
+				},
+				test: function (element, props){
+					prop = props.mooCustom;
+					return false;
+				}
+			});
+
+			var form = new Element('form').adopt(
+			new Element('input', {
+				'type': 'text',
+				'name': 'foo',
+				'class': "validate-string-fail mooCustom:'Hello-World!'"
+			})).inject($(document.body));
+
+			new Form.Validator.Inline(form);
+			form.validate();
+			expect(prop).toEqual('Hello-World!');
+			form.dispose();
+		});
 
 	});
 


### PR DESCRIPTION
fixes #1264

JSON.decode defaults to secure since 1.5. This code was relying on
`eval()`, so by forcing JSON.decode to unsecure the code works again

Added new spec to cover this
