### PR TITLE
Type error fix for empty string on 'validate-date'

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -455,13 +455,15 @@ Form.Validator.addAllThese([
 				value = element.get('value'),
 				wordsInValue = value.match(/[a-z]+/gi);
 
-				if (wordsInValue && !wordsInValue.every(dateNouns.exec, dateNouns)) return false;
+			if (wordsInValue && !wordsInValue.every(dateNouns.exec, dateNouns)) return false;
 
-				var date = Date.parse(value),
-					format = props.dateFormat || '%x',
-					formatted = date.format(format);
-				if (formatted != 'invalid date') element.set('value', formatted);
-				return date.isValid();
+			var date = Date.parse(value);
+			if (!date) return false;
+
+			var format = props.dateFormat || '%x',
+				formatted = date.format(format);
+			if (formatted != 'invalid date') element.set('value', formatted);
+			return date.isValid();
 		}
 	}],
 

--- a/Specs/Forms/Form.Validator.js
+++ b/Specs/Forms/Form.Validator.js
@@ -314,6 +314,10 @@ describe('Form.Validator', function(){
 				expect(validator.test(createInput('Boo 12'))).toEqual(false);
 			});
 
+			it('should return false, instead of Type Error, when passed a empty string', function(){
+				expect(validator.test(createInput('    '))).toBeFalsy()
+			});
+
 			it('should return true for fields whose value parses to a date', function(){
 				expect(validator.test(createInput('Nov 12'))).toEqual(true);
 				expect(validator.test(createInput('10-10-2000'))).toEqual(true);


### PR DESCRIPTION
fixes #1030

When input value is a empty string of spaces, date-validator returns
`null`, and `formatted = date.format(format);` at [L462](https://github.com/mootools/mootools-more/blob/master/Source/Forms/Form.Validator.js#L462) gives a type error (http://jsfiddle.net/8YH3w/). 

```
TypeError: Cannot read property 'format' of null
```

This commit returns false on such cases and corrects indent at lines [458-464](https://github.com/mootools/mootools-more/blob/master/Source/Forms/Form.Validator.js#L458-L464).
