### PR TITLE
update credit card regex

### DIFF
--- a/Source/Forms/Form.Validator.Extras.js
+++ b/Source/Forms/Form.Validator.Extras.js
@@ -194,7 +194,8 @@ Form.Validator.addAllThese([
 			if (ccNum.test(/^4[0-9]{12}([0-9]{3})?$/)) valid_type = 'Visa';
 			else if (ccNum.test(/^5[1-5]([0-9]{14})$/)) valid_type = 'Master Card';
 			else if (ccNum.test(/^3[47][0-9]{13}$/)) valid_type = 'American Express';
-			else if (ccNum.test(/^6011[0-9]{12}$/)) valid_type = 'Discover';
+			else if (ccNum.test(/^6(?:011|5[0-9]{2})[0-9]{12}$/)) valid_type = 'Discover';
+			else if (ccNum.test(/^3(?:0[0-5]|[68][0-9])[0-9]{11}$/)) valid_type = 'Diners Club';
 
 			if (valid_type){
 				var sum = 0;


### PR DESCRIPTION
fixes #1138

Update credit card regex.

Source: [stoackoverflow](http://stackoverflow.com/questions/72768/how-do-you-detect-credit-card-type-based-on-number). 
Others: [stackoverflow 2](http://stackoverflow.com/a/9315696/2256325), [web1](http://www.regular-expressions.info/creditcard.html), [web2](https://gist.github.com/nerdsrescueme/1237767), [stackoverflow 3](http://stackoverflow.com/a/1463289/2256325) - _all use same regex_.
