### PR TITLE
use new packager version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function(grunt) {
 
 			options: {
 				name: {
-					More: null, 
+					More: 'Source/', 
 					Core: 'node_modules/mootools-core/'
 				}
 			},

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mootools-core": "https://github.com/mootools/mootools-core/tarball/master",
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.13",
-    "grunt-mootools-packager": "https://github.com/SergioCrisostomo/grunt-packager/tarball/master",
+    "grunt-mootools-packager": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-connect": "~0.7.0",
     "grunt-karma": "~0.8.0",


### PR DESCRIPTION
Update to replace my repo's `tarball` for new version of mootools packager from NPM
