### PR TITLE
Update Drag.js -- implicit global variable

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -122,7 +122,7 @@ var Drag = new Class({
 
 	sumValues: function(alpha, beta, op){
 		var sum = {}, options = this.options;
-		for (z in options.modifiers){
+		for (var z in options.modifiers){
 			if (!options.modifiers[z]) continue;
 			sum[z] = alpha[z] + beta[z] * op;
 		}


### PR DESCRIPTION
In sumValues, z isn't declared as a var, and therefore becomes a global. This change corrects this.
