### PR TITLE
fix Scroller

### DIFF
--- a/Source/Interface/Scroller.js
+++ b/Source/Interface/Scroller.js
@@ -85,7 +85,7 @@ var Scroller = new Class({
 	scroll: function(){
 		var size = this.element.getSize(),
 			scroll = this.element.getScroll(),
-			pos = ((this.element != this.docBody) && (this.element != window)) ? element.getOffsets() : {x: 0, y: 0},
+			pos = ((this.element != this.docBody) && (this.element != window)) ? this.element.getOffsets() : {x: 0, y: 0},
 			scrollSize = this.element.getScrollSize(),
 			change = {x: 0, y: 0},
 			top = this.options.area.top || this.options.area,

--- a/Specs/Interface/Scroller.js
+++ b/Specs/Interface/Scroller.js
@@ -1,0 +1,48 @@
+/*
+---
+name: Scroller Tests
+requires: [Core/Events, Core/Options, Core/Element.Event, Core/Element.Dimensions, MooTools.More]
+provides: [Scroller.Tests]
+...
+*/
+describe('Scroller', function(){
+
+    var inner, wrapper, myScroller, body = $(document.body);
+
+    beforeEach(function(){
+        wrapper = new Element('div', {
+            id: 'myScroll',
+            styles: {
+                width: 300,
+                height: 200,
+                overflow: 'scroll'
+            }
+        });
+        wrapper.inject(body);
+        inner = new Element('div', {
+            styles: {
+                width: 600,
+                height: 400
+            }
+        }).inject(wrapper);
+
+        myScroller = new Scroller('myScroll', {
+            area: Math.round(window.getWidth() / 10)
+        });
+    });
+
+    afterEach(function(){
+        inner.destroy();
+        wrapper.destroy();
+        myScroller = null;
+    });
+
+    it('should initialize', function(){
+        expect(myScroller.element).toEqual(wrapper);
+    });
+
+    it('should be error free when calling .scroll()', function(){
+        expect(myScroller.scroll()).toBe(undefined);
+    });
+
+});


### PR DESCRIPTION
In a previous fix I missed a "`this.`". This PR fixes that.
Added also a simple spec. Not the most fancy in the world but it would have avoided my bug.

thank you @RemkoNolten for pointing this out.
