### PR TITLE
Fixes wrong module definitions

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -26,8 +26,9 @@ provides: [Drag]
 ...
 
 */
+(function(){
 
-var Drag = new Class({
+var Drag = this.Drag = new Class({
 
 	Implements: [Events, Options],
 
@@ -249,6 +250,9 @@ var Drag = new Class({
 	}
 
 });
+
+})();
+
 
 Element.implement({
 

--- a/Source/Drag/Slider.js
+++ b/Source/Drag/Slider.js
@@ -23,8 +23,9 @@ provides: [Slider]
 
 ...
 */
+(function(){
 
-var Slider = new Class({
+var Slider = this.Slider = new Class({
 
 	Implements: [Events, Options],
 
@@ -236,3 +237,6 @@ var Slider = new Class({
 	}
 
 });
+
+})();
+

--- a/Source/Drag/Sortables.js
+++ b/Source/Drag/Sortables.js
@@ -20,8 +20,9 @@ provides: [Sortables]
 
 ...
 */
+(function(){
 
-var Sortables = new Class({
+var Sortables = this.Sortables = new Class({
 
 	Implements: [Events, Options],
 
@@ -253,3 +254,5 @@ var Sortables = new Class({
 	}
 
 });
+
+})();

--- a/Source/Forms/OverText.js
+++ b/Source/Forms/OverText.js
@@ -25,8 +25,9 @@ provides: [OverText]
 
 ...
 */
+(function(){
 
-var OverText = new Class({
+var OverText = this.OverText = new Class({
 
 	Implements: [Options, Events, Class.Occlude],
 
@@ -220,6 +221,8 @@ var OverText = new Class({
 	}
 
 });
+
+})();
 
 OverText.instances = [];
 

--- a/Source/Interface/HtmlTable.js
+++ b/Source/Interface/HtmlTable.js
@@ -21,8 +21,9 @@ provides: [HtmlTable]
 
 ...
 */
+(function(){
 
-var HtmlTable = new Class({
+var HtmlTable = this.HtmlTable = new Class({
 
 	Implements: [Options, Events, Class.Occlude],
 
@@ -145,6 +146,8 @@ var HtmlTable = new Class({
 	}
 
 });
+
+})();
 
 
 ['adopt', 'inject', 'wraps', 'grab', 'replaces', 'dispose'].each(function(method){

--- a/Source/Interface/Mask.js
+++ b/Source/Interface/Mask.js
@@ -24,8 +24,9 @@ provides: [Mask]
 
 ...
 */
+(function(){
 
-var Mask = new Class({
+var Mask = this.Mask = new Class({
 
 	Implements: [Options, Events],
 
@@ -175,6 +176,9 @@ var Mask = new Class({
 	}
 
 });
+
+})();
+
 
 Element.Properties.mask = {
 

--- a/Source/Interface/Scroller.js
+++ b/Source/Interface/Scroller.js
@@ -23,8 +23,9 @@ provides: [Scroller]
 
 ...
 */
+(function(){
 
-var Scroller = new Class({
+var Scroller = this.Scroller = new Class({
 
 	Implements: [Events, Options],
 
@@ -102,3 +103,6 @@ var Scroller = new Class({
 	}
 
 });
+
+})();
+

--- a/Source/Interface/Spinner.js
+++ b/Source/Interface/Spinner.js
@@ -22,10 +22,11 @@ provides: [Spinner]
 
 ...
 */
+(function(){
 
-var Spinner = new Class({
+var Spinner = this.Spinner = new Class({
 
-	Extends: Mask,
+	Extends: this.Mask,
 
 	Implements: Chain,
 
@@ -149,6 +150,8 @@ var Spinner = new Class({
 	}
 
 });
+
+})();
 
 Request = Class.refactor(Request, {
 

--- a/Source/Interface/Tips.js
+++ b/Source/Interface/Tips.js
@@ -33,7 +33,7 @@ var read = function(option, element){
 	return (option) ? (typeOf(option) == 'function' ? option(element) : element.get(option)) : '';
 };
 
-this.Tips = new Class({
+var Tips = this.Tips = new Class({
 
 	Implements: [Events, Options],
 

--- a/Source/Utilities/Assets.js
+++ b/Source/Utilities/Assets.js
@@ -20,8 +20,9 @@ provides: [Assets]
 
 ...
 */
+;(function(){
 
-var Asset = {
+var Asset = this.Asset = {
 
 	javascript: function(source, properties){
 		if (!properties) properties = {};
@@ -147,3 +148,5 @@ var Asset = {
 	}
 
 };
+
+})();

--- a/Source/Utilities/Group.js
+++ b/Source/Utilities/Group.js
@@ -23,7 +23,7 @@ provides: [Group]
 
 (function(){
 
-this.Group = new Class({
+var Group = this.Group = new Class({
 
 	initialize: function(){
 		this.instances = Array.flatten(arguments);

--- a/Source/Utilities/IframeShim.js
+++ b/Source/Utilities/IframeShim.js
@@ -32,7 +32,7 @@ var browsers = false;
 browsers = Browser.ie6 || (Browser.firefox && Browser.version < 3 && Browser.Platform.mac);
 //</1.4compat>
 
-this.IframeShim = new Class({
+var IframeShim = this.IframeShim = new Class({
 
 	Implements: [Options, Events, Class.Occlude],
 


### PR DESCRIPTION
This PR fixes #1310 and #1294.

Some modules wasn't well defined to use them with a dependency loader.

I've checked all modules and these are what I found:
Drag, Slider, Sortables, OverText, HtmlTable, Mask, Scroller, Spinner, Asset.

I've also changed some modules to follow the same module definition format:
Tips, Group, IframeShim

Although this doesn't make them CommonJS compliance, it's enough to load all modules in the global scope (window).

If you are using webpack, you can include the library with this workaround without any problems now:
```js
require('imports?this=>window!path/to/mootools-more-all.js);
```