### PR TITLE
String.QueryString: fix bug decoding '+'

### DIFF
--- a/Source/Types/String.QueryString.js
+++ b/Source/Types/String.QueryString.js
@@ -25,6 +25,22 @@ provides: [String.QueryString]
 ...
 */
 
+(function(){
+
+/**
+ * decodeURIComponent doesn't do the correct thing with query parameter keys or
+ * values. Specifically, it leaves '+' as '+' when it should be converting them
+ * to spaces as that's the specification. When browsers submit HTML forms via
+ * GET, the values are encoded using 'application/x-www-form-urlencoded'
+ * which converts spaces to '+'.
+ *
+ * See: http://unixpapa.com/js/querystring.html for a description of the
+ * problem.
+ */
+var decodeComponent = function(str){
+	return decodeURIComponent(str.replace('+', ' '));
+};
+
 String.implement({
 
 	parseQueryString: function(decodeKeys, decodeValues){
@@ -41,9 +57,9 @@ String.implement({
 				keys = index ? val.substr(0, index - 1).match(/([^\]\[]+|(\B)(?=\]))/g) : [val],
 				obj = object;
 			if (!keys) return;
-			if (decodeValues) value = decodeURIComponent(value);
+			if (decodeValues) value = decodeComponent(value);
 			keys.each(function(key, i){
-				if (decodeKeys) key = decodeURIComponent(key);
+				if (decodeKeys) key = decodeComponent(key);
 				var current = obj[key];
 
 				if (i < keys.length - 1) obj = obj[key] = current || {};
@@ -66,3 +82,5 @@ String.implement({
 	}
 
 });
+
+})()

--- a/Source/Types/String.QueryString.js
+++ b/Source/Types/String.QueryString.js
@@ -38,7 +38,7 @@ provides: [String.QueryString]
  * problem.
  */
 var decodeComponent = function(str){
-	return decodeURIComponent(str.replace('+', ' '));
+	return decodeURIComponent(str.replace(/\+/g, ' '));
 };
 
 String.implement({

--- a/Specs/Types/String.QueryString.js
+++ b/Specs/Types/String.QueryString.js
@@ -40,6 +40,10 @@ provides: [String.QueryString.Tests]
 			expect('this%20should%20be%20encoded=oh%20dear'.parseQueryString(false, false)).toEqual({'this%20should%20be%20encoded': 'oh%20dear'});
 		});
 
+		it('should parse + into space', function(){
+			expect('this+should=be+spaces'.parseQueryString()).toEqual({'this should': 'be spaces'});
+		});
+
 		it('should parse a collection correctly', function(){
 			expect(Hash.toQueryString('f[28][]=110&order=pv'.parseQueryString())).toEqual('f[28][]=110&order=pv');
 		});

--- a/Specs/Types/String.QueryString.js
+++ b/Specs/Types/String.QueryString.js
@@ -41,7 +41,7 @@ provides: [String.QueryString.Tests]
 		});
 
 		it('should parse + into space', function(){
-			expect('this+should=be+spaces'.parseQueryString()).toEqual({'this should': 'be spaces'});
+			expect('this+should=all+be+spaces'.parseQueryString()).toEqual({'this should': 'all be spaces'});
 		});
 
 		it('should parse a collection correctly', function(){

--- a/Specs/Types/URI.js
+++ b/Specs/Types/URI.js
@@ -64,6 +64,10 @@ provides: [URI.Tests]
 			expect(new URI('..', { base: 'http://www.calyptus.eu/mydirectory/mydirectory2/myfile.html' }).toString()).toEqual('http://www.calyptus.eu/mydirectory/');
 		});
 
+		it('Should decode + into space in the query portion of the url', function(){
+			expect(new URI('http://example.com/?key=a+b%2Bc').getData('key')).toEqual('a b+c');
+		});
+
 		it('Query String can contain @ symbol', function(){
 			expect(new URI('http://www.calyptus.eu/myfile.html?email=somebody@gmail.com').get('host')).toEqual('www.calyptus.eu');
 		});


### PR DESCRIPTION
decodeURIComponent doesn't do the correct thing with query parameter
keys or values. Specifically, it leaves '+' as '+' when it should be
converting them to spaces as that's the specification. When browsers
submit HTML forms via GET, the values are encoded using
the 'application/x-www-form-urlencoded' mime type which converts
spaces to '+'. decodeURIComponent() will then give incorrect results
on components of the query string.

See: http://unixpapa.com/js/querystring.html for a description of the
problem.
