### PR TITLE
remove old callbacks in Request.JSONP.request_map

### DIFF
--- a/Source/Request/Request.JSONP.js
+++ b/Source/Request/Request.JSONP.js
@@ -72,7 +72,8 @@ Request.JSONP = new Class({
 			case 'object': case 'hash': data = Object.toQueryString(data);
 		}
 
-		var index = this.index = Request.JSONP.counter++;
+		var index = this.index = Request.JSONP.counter++,
+			key = 'request_' + index;
 
 		var src = options.url +
 			(options.url.test('\\?') ? '&' :'?') +
@@ -82,8 +83,8 @@ Request.JSONP = new Class({
 
 		if (src.length > 2083) this.fireEvent('error', src);
 
-		Request.JSONP.request_map['request_' + index] = function(){
-			delete Request.JSONP.request_map['request_' + index];
+		Request.JSONP.request_map[key] = function(){
+			delete Request.JSONP.request_map[key];
 			this.success(arguments, index);
 		}.bind(this);
 
@@ -104,7 +105,7 @@ Request.JSONP = new Class({
 		return this.script;
 	},
 
-	success: function(args, index){
+	success: function(args){
 		if (!this.running) return;
 		this.clear()
 			.fireEvent('complete', args).fireEvent('success', args)

--- a/Source/Request/Request.JSONP.js
+++ b/Source/Request/Request.JSONP.js
@@ -83,6 +83,7 @@ Request.JSONP = new Class({
 		if (src.length > 2083) this.fireEvent('error', src);
 
 		Request.JSONP.request_map['request_' + index] = function(){
+			delete Request.JSONP.request_map['request_' + index];
 			this.success(arguments, index);
 		}.bind(this);
 

--- a/Specs/Request/Request.JSONP.js
+++ b/Specs/Request/Request.JSONP.js
@@ -7,6 +7,11 @@ provides: [Request.JSONP.Tests]
 */
 describe('Request.JSONP', function(){
 
+	function checkStoredRequestMap(expected){
+		var storedCallbacks = Object.keys(Request.JSONP.request_map).length;
+		expect(storedCallbacks).toBe(expected);
+	}
+
 	it('should grab some json from from assets/jsonp.js', function(){
 
 		var onComplete = jasmine.createSpy(),
@@ -50,6 +55,31 @@ describe('Request.JSONP', function(){
 			expect(onComplete.mostRecentCall.args[0].test).toEqual(true);
 		});
 
+	});
+
+	it('should clear the request callback map', function(){
+
+		var complete = false;
+		checkStoredRequestMap(0);
+		var request = new Request.JSONP({
+			url: 'base/Tests/Specs/assets/jsonp.js',
+			onComplete: function(){
+				checkStoredRequestMap(0);
+				complete = true;
+			},
+			onRequest: function(src, script){
+				checkStoredRequestMap(1);
+			},
+			clearRequestMap: true
+		}).send();
+		
+		waitsFor(1600, function(){
+			return complete;
+		});
+
+		runs(function(){
+			expect(complete).toBeTruthy();
+		});
 	});
 
 });

--- a/Tests/Specs/assets/jsonp.js
+++ b/Tests/Specs/assets/jsonp.js
@@ -1,8 +1,16 @@
 
-Request.JSONP.request_map.request_0({
+if (Request.JSONP.request_map.request_0) Request.JSONP.request_map.request_0({
 
 	some: {very: {intersting: 'data'}},
 	and: [1, 2, 3],
+	test: true
+
+});
+
+if (Request.JSONP.request_map.request_1) Request.JSONP.request_map.request_1({
+
+	even: {more: {intersting: 'stuff'}},
+	and: [8, 9, 10],
 	test: true
 
 });


### PR DESCRIPTION
fixes #1293

Add option to remove old `Request.JSONP.request_map` callbacks. Defaults to `false` to be BC.
