### PR TITLE
Fix for validator properties with spaces

### DIFF
--- a/Source/Forms/Form.Validator.js
+++ b/Source/Forms/Form.Validator.js
@@ -69,7 +69,9 @@ var InputValidator = this.InputValidator = new Class({
 Element.Properties.validators = {
 
 	get: function(){
-		return (this.get('data-validators') || this.className).clean().split(' ');
+		return (this.get('data-validators') || this.className).clean().replace(/'(\\.|[^'])*'|"(\\.|[^"])*"/g, function(match){
+			return match.replace(' ', '\\x20');
+		}).split(' ');
 	}
 
 };

--- a/Specs/Forms/Form.Validator.js
+++ b/Specs/Forms/Form.Validator.js
@@ -19,6 +19,11 @@ describe('Form.Validator', function(){
 			expect(element.get('validatorProps')).toEqual({minLength: 10});
 		});
 
+		it('should get the properties from string with spaces', function(){
+			var input = new Element('input', {'data-validators': 'label:\'primary category\''});
+			expect(input.get('validatorProps')).toEqual({label: "primary category"});
+		});
+
 		it('should get the validator properties from a JSON string in the validatorProps attribute', function(){
 			var element = new Element('input').setProperty('validatorProps', '{minLength: 10, maxLength:20}');
 			expect(element.get('validatorProps')).toEqual({minLength: 10, maxLength: 20});


### PR DESCRIPTION
`.get('validatorProps')` fails when there are spaces in the `data-validators` attribute.

If we do `input.set('validatorProps', {label: 'primary category'});` this [works good](http://jsfiddle.net/0o56hL6r/) and `input.get('validatorProps');` returns `Object {label: "primary category"}`.

But when we have in the HTML

    <input type="text" data-validators="label:'primary category'"/>

then [the method fails](http://jsfiddle.net/0o56hL6r/1/) and we get `Object {}`.

This PR is a rebased version of fixes suggested by @kulbakin and fixes the problem for HTML with spaces in the `data-validators`.

closes #1213