### PR TITLE
fix scroll bug is page is using SVG

### DIFF
--- a/Source/Forms/Form.Validator.Inline.js
+++ b/Source/Forms/Form.Validator.Inline.js
@@ -160,7 +160,7 @@ Form.Validator.Inline = new Class({
 		if (((this.options.scrollToErrorsOnSubmit && scroll == null) || scroll) && !result){
 			var failed = document.id(this).getElement('.validation-failed');
 			var par = document.id(this).getParent();
-			while (par != document.body && par.getScrollSize().y == par.getSize().y){
+			while (par != document.body){
 				par = par.getParent();
 			}
 			var fx = par.retrieve('$moo:fvScroller');


### PR DESCRIPTION
par.getSize().y gives float after More >= 1.5.1 and SVG is used on the page so code can't find document.body and can't scroll