### PR TITLE
add sort order to onSort function arguments

### DIFF
--- a/Docs/Interface/HtmlTable.Sort.md
+++ b/Docs/Interface/HtmlTable.Sort.md
@@ -40,7 +40,7 @@ HtmlTable Method: constructor
 
 ### Events
 
-* sort - callback executed when a column is sorted; passed the *tbody* and the index of the column sorted.
+* sort - callback executed when a column is sorted; passed the *tbody* (Element), the index of the column sorted (Integer) and which direction the table is sorted ("asc" or "desc").
 
 ### Note
 

--- a/Source/Interface/HtmlTable.Sort.js
+++ b/Source/Interface/HtmlTable.Sort.js
@@ -230,12 +230,13 @@ HtmlTable = Class.refactor(HtmlTable, {
 			return a.value > b.value ? 1 : -1;
 		});
 
-		if (this.sorted.reverse == (parser == HtmlTable.Parsers['input-checked'])) data.reverse(true);
+		var reverse = this.sorted.reverse == (parser == HtmlTable.Parsers['input-checked']);
+		if (reverse) data.reverse(true);
 		this.setRowSort(data, pre);
 
 		if (rel) rel.grab(this.body);
 		this.fireEvent('stateChanged');
-		return this.fireEvent('sort', [this.body, this.sorted.index]);
+		return this.fireEvent('sort', [this.body, this.sorted.index, reverse ? 'asc' : 'desc']);
 	},
 
 	parseData: function(parser){

--- a/Specs/Interface/HtmlTable.Sort.js
+++ b/Specs/Interface/HtmlTable.Sort.js
@@ -6,6 +6,12 @@ provides: [HtmlTable.Sort.Tests]
 ...
 */
 describe('HtmlTable.Sort', function(){
+	
+	function getText(rows){
+		return Array.map(rows, function(item){
+			return item.cells[0].get('text') || item.cells[0].getElement('input').get('value');
+		});
+	}
 
   it('should not step on prior this.bind declarations', function () {
     var table = new HtmlTable();
@@ -22,9 +28,7 @@ describe('HtmlTable.Sort', function(){
 				rows: data.map(function(item){return [item];})
 			});
 
-			return Array.map(table.sort(0, false).body.rows, function(item){
-				return item.cells[0].get('text') || item.cells[0].getElement('input').get('value');
-			});
+			return getText(table.sort(0, false).body.rows);
 		};
 
 		describe('date', function(){
@@ -116,6 +120,38 @@ describe('HtmlTable.Sort', function(){
 
 			it('should correctly sort alpha-floats according to value', function(){
 				expect(sortedTable('float', ['.2b', '1c', '.03a'])).toEqual(['.03a', '.2b', '1c']);
+			});
+
+		});
+
+		describe('onSort event', function(){
+			var status, args, tbody;
+			var table = new HtmlTable({
+				sortable: true,
+				headers: ['col'],
+				parsers: ['string'],
+				rows: [['a'], ['c'], ['b']],
+				onSort: function(body, index, reversed){
+					args = arguments;
+					tbody = body;
+					status = reversed;
+				}
+			});
+
+			it('should set function arguments', function(){
+				expect(args.length).toEqual(3);
+				expect(args[0].tagName.toLowerCase()).toEqual('tbody');
+				expect(typeof args[1]).toEqual('number');
+				expect(typeof args[2]).toEqual('string');
+			});
+			
+			it('should correctly set the direction onSort event', function(){
+				table.sort(0, false);
+				expect(status).toEqual('asc');
+				expect(getText(tbody.rows)).toEqual(['a', 'b', 'c']);
+				table.sort(0, true);
+				expect(status).toEqual('desc');
+				expect(getText(tbody.rows)).toEqual(['c', 'b', 'a']);
 			});
 
 		});


### PR DESCRIPTION
When sorting a table the `onSort` function does not tell which direction the sort happens.
Following @oskarkrawczyk 's work I made this PR to fix that.

This would make possible to know if if the reversed state is `true` or `false`. 

fixes #1193