### PR TITLE
update Form.Validator.Inline dependencies

### DIFF
--- a/Source/Forms/Form.Validator.Inline.js
+++ b/Source/Forms/Form.Validator.Inline.js
@@ -14,6 +14,7 @@ authors:
 
 requires:
   - Form.Validator
+  - Core/Element.Dimensions
 
 provides: [Form.Validator.Inline]
 


### PR DESCRIPTION
As pointed out at https://github.com/mootools/website/issues/228 the dependecy chain is not correct for `Form.Validator.Inline` that depends on `.getScrollSize()` and `.getScroll()`. Both methods can be found at `Core/Element.Dimensions`.

