### PR TITLE
Check if there is a drag handle in Drag.start().

### DIFF
--- a/Source/Drag/Drag.js
+++ b/Source/Drag/Drag.js
@@ -134,7 +134,7 @@ var Drag = this.Drag = new Class({
 	},
 
 	start: function(event){
-		if (this.options.unDraggableTags.contains(event.target.get('tag'))) return;
+		if (!this.options.handle && this.options.unDraggableTags.contains(event.target.get('tag'))) return;
 
 		var options = this.options;
 


### PR DESCRIPTION
Similar to https://github.com/mootools/mootools-more/blob/master/Source/Drag/Sortables.js#L171, you should check if there is a drag handle before checking the `unDraggableTags` option.